### PR TITLE
fix: generate unique firebaseToken for web extension

### DIFF
--- a/web-extension/src/pages-vault/LoginAwaitingApproval.tsx
+++ b/web-extension/src/pages-vault/LoginAwaitingApproval.tsx
@@ -69,7 +69,9 @@ export const useLogin = (props: { deviceName: string }) => {
   const deviceDecryptionChallenge = decryptionData?.deviceDecryptionChallenge
 
   useEffect(() => {
-    const { fireToken } = device
+    // Generate a unique firebaseToken if not available (Firebase doesn't work in extensions)
+    // Use UUID to ensure uniqueness across logins
+    const fireToken = device.fireToken || `web-ext-${crypto.randomUUID()}`
 
     console.log('~ decryptionData', decryptionData)
     if (

--- a/web-extension/src/pages-vault/Register.tsx
+++ b/web-extension/src/pages-vault/Register.tsx
@@ -63,10 +63,9 @@ export default function Register() {
   const navigate = useNavigate()
   const toast = useToast()
 
-  const { fireToken } = device
-  if (!fireToken) {
-    return <Spinner />
-  }
+  // Generate a unique firebaseToken if not available (Firebase doesn't work in extensions)
+  // Use deviceId + timestamp to ensure uniqueness across registrations
+  const fireToken = device.fireToken || `web-ext-${crypto.randomUUID()}`
 
   return (
     <Box


### PR DESCRIPTION
Firebase doesn't work in browser extensions, so device.fireToken is always null. Instead of sending null or a placeholder value that could collide, generate a unique token using crypto.randomUUID() prefixed with 'web-ext-'.

This prevents unique constraint violations on the firebaseToken field when multiple devices or registration attempts use the same placeholder value.

Changes:
- Register.tsx: Generate unique token if device.fireToken is null
- LoginAwaitingApproval.tsx: Generate unique token if device.fireToken is null

The backend firebaseToken field is nullable and has a unique constraint, so this ensures each web extension device gets a unique token without backend changes.