### PR TITLE
Guard autofill and auto-submit with viewport visibility checks

### DIFF
--- a/web-extension/src/content-script/autofill.ts
+++ b/web-extension/src/content-script/autofill.ts
@@ -2,7 +2,7 @@ import { bodyInputChangeEmitter } from './domMutationObserver'
 import { generateSync } from 'otplib'
 import debug from 'debug'
 import { generate } from 'generate-password'
-import { isElementInViewport, isHidden } from './isElementInViewport'
+import { isElementVisibleInViewport } from './isElementInViewport'
 import { domRecorder, IInitStateRes } from './contentScript'
 import { WebInputType } from '../../../shared/generated/graphqlBaseTypes'
 import { authierColors } from '../../../shared/chakraRawTheme'
@@ -330,8 +330,8 @@ export const autofillValueIntoInput = (
     filledElements.add(element)
   }
 
-  if (isElementInViewport(element) === false || isHidden(element)) {
-    log('isHidden')
+  if (!isElementVisibleInViewport(element)) {
+    log('input is not visible in viewport, skipping autofill')
     return null // could be dangerous to autofill into a hidden element-if the website got hacked, someone could be using this: https://websecurity.dev/password-managers/autofill/
   }
 
@@ -694,7 +694,11 @@ export const autofill = (initState: IInitStateRes) => {
     if (filledElements.size === 2) {
       const filledElementsArray = Array.from(filledElements)
       const form = filledElementsArray[0]?.form
-      if (form) {
+      const areFilledElementsVisible = filledElementsArray.every((inputEl) =>
+        isElementVisibleInViewport(inputEl)
+      )
+
+      if (form && isElementVisibleInViewport(form) && areFilledElementsVisible) {
         const clickEvent = new MouseEvent('click', {
           view: window,
           bubbles: true,
@@ -721,6 +725,10 @@ export const autofill = (initState: IInitStateRes) => {
             `Submitted autofilled form for user "${notAPasswordInput.value}"`
           )
         }
+      } else {
+        log(
+          'skipping submit for autofilled form because form or filled inputs are not visible in viewport'
+        )
       }
     }
 

--- a/web-extension/src/content-script/isElementInViewport.spec.ts
+++ b/web-extension/src/content-script/isElementInViewport.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isElementInViewport,
+  isElementVisibleInViewport,
+  isHidden
+} from './isElementInViewport'
+
+describe('isElementInViewport', () => {
+  it('returns true when element bounds are inside viewport', () => {
+    const el = document.createElement('input')
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top: 10,
+      left: 10,
+      bottom: 20,
+      right: 20,
+      width: 10,
+      height: 10,
+      x: 10,
+      y: 10,
+      toJSON: () => ({})
+    })
+
+    expect(isElementInViewport(el)).toBe(true)
+  })
+
+  it('returns false when element is outside viewport', () => {
+    const el = document.createElement('input')
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top: 10,
+      left: 10,
+      bottom: window.innerHeight + 10,
+      right: 20,
+      width: 10,
+      height: 10,
+      x: 10,
+      y: 10,
+      toJSON: () => ({})
+    })
+
+    expect(isElementInViewport(el)).toBe(false)
+  })
+})
+
+describe('visibility helpers', () => {
+  it('marks display none element as hidden', () => {
+    const el = document.createElement('input')
+    el.style.display = 'none'
+
+    expect(isHidden(el)).toBe(true)
+  })
+
+  it('requires connected element with box and in viewport', () => {
+    const el = document.createElement('input')
+    document.body.appendChild(el)
+
+    vi.spyOn(el, 'getClientRects').mockReturnValue([
+      {
+        bottom: 20,
+        height: 10,
+        left: 10,
+        right: 20,
+        top: 10,
+        width: 10,
+        x: 10,
+        y: 10,
+        toJSON: () => ({})
+      }
+    ] as unknown as DOMRectList)
+
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top: 10,
+      left: 10,
+      bottom: 20,
+      right: 20,
+      width: 10,
+      height: 10,
+      x: 10,
+      y: 10,
+      toJSON: () => ({})
+    })
+
+    expect(isElementVisibleInViewport(el)).toBe(true)
+  })
+
+  it('returns false for detached element', () => {
+    const el = document.createElement('input')
+
+    expect(isElementVisibleInViewport(el)).toBe(false)
+  })
+})

--- a/web-extension/src/content-script/isElementInViewport.ts
+++ b/web-extension/src/content-script/isElementInViewport.ts
@@ -18,7 +18,29 @@ export function isElementInViewport(el: HTMLElement): boolean {
   )
 }
 
-export function isHidden(el) {
+export function isHidden(el: HTMLElement): boolean {
   const style = window.getComputedStyle(el)
-  return style.display === 'none'
+  return (
+    style.display === 'none' ||
+    style.visibility === 'hidden' ||
+    style.visibility === 'collapse' ||
+    style.opacity === '0' ||
+    el.hidden
+  )
+}
+
+export function isElementVisibleInViewport(el: HTMLElement): boolean {
+  if (!el.isConnected) {
+    return false
+  }
+
+  if (el.getClientRects().length === 0) {
+    return false
+  }
+
+  if (isHidden(el)) {
+    return false
+  }
+
+  return isElementInViewport(el)
 }

--- a/web-extension/src/content-script/isElementInViewport.ts
+++ b/web-extension/src/content-script/isElementInViewport.ts
@@ -20,12 +20,14 @@ export function isElementInViewport(el: HTMLElement): boolean {
 
 export function isHidden(el: HTMLElement): boolean {
   const style = window.getComputedStyle(el)
+  const isHiddenAttributeSet = el.hidden === true
+
   return (
     style.display === 'none' ||
     style.visibility === 'hidden' ||
     style.visibility === 'collapse' ||
     style.opacity === '0' ||
-    el.hidden
+    isHiddenAttributeSet
   )
 }
 


### PR DESCRIPTION
### Motivation
- Prevent autofilling and auto-submitting forms that are not visible to the user (off-screen or hidden), which can cause invisible or irrelevant forms to be filled/submitted.
- Avoid unsafe autofills into elements that are detached, collapsed, or styled out of view, addressing cases like pages that contain hidden forms that get auto-submitted.

### Description
- Added `isElementVisibleInViewport` in `web-extension/src/content-script/isElementInViewport.ts` which requires the element to be connected, have client rects, not be hidden (`display:none`, `visibility:hidden/collapse`, `opacity:0`, or `hidden` attribute), and be inside the viewport, and improved `isHidden` accordingly.
- Updated `autofillValueIntoInput` in `web-extension/src/content-script/autofill.ts` to skip autofill when an input is not visible in the viewport by using `isElementVisibleInViewport` and log the skip.
- Updated auto-submit logic in `autofill.ts` to only dispatch submit when the form and all autofilled inputs are visible in the viewport; otherwise the submit is skipped and a log entry is emitted.
- Added unit tests `web-extension/src/content-script/isElementInViewport.spec.ts` to cover viewport and visibility helper behavior.

### Testing
- Ran `cd web-extension && pnpm vitest run src/content-script/isElementInViewport.spec.ts` and the tests passed: 1 test file, 5 tests passed.
- (An earlier direct `pnpm --dir web-extension vitest run ...` invocation failed due to the workspace invocation; the correct command above was used to run the tests successfully.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc703785c8332a0c377835ede7434)