### PR TITLE
Add option to remove saved autofill inputs for current page in AuthsList

### DIFF
--- a/web-extension/src/components/pages/AuthsList.tsx
+++ b/web-extension/src/components/pages/AuthsList.tsx
@@ -16,6 +16,9 @@ import { getDomainNameAndTldFromUrl } from '@shared/urlUtils'
 import { EncryptedSecretType } from '@shared/generated/graphqlBaseTypes'
 import { PopupActionsEnum } from './PopupActionsEnum'
 import { SquareMousePointer } from './SquareMousePointerIcon'
+import { useRemoveWebInputMutation } from '../vault/VaultItemSettings.codegen'
+import { device } from '@src/background/ExtensionDevice'
+import { getWebInputsForUrl } from '@src/background/getWebInputsForUrl'
 
 const log = debug('au:AuthsList')
 
@@ -178,6 +181,7 @@ export const AuthsList = ({
     currentURL,
     searchSecrets
   } = useContext(DeviceStateContext)
+  const [removeWebInput] = useRemoveWebInputMutation()
 
   if (!deviceState) {
     return null
@@ -212,6 +216,9 @@ export const AuthsList = ({
   )
 
   const hasNoSecrets = deviceState.secrets.length === 0
+  const matchingWebInputsForCurrentPage = currentURL
+    ? getWebInputsForUrl(currentURL)
+    : []
   const totps = searchSecrets(search, [EncryptedSecretType.TOTP]) as ITOTPSecret[]
   const creds = searchSecrets(search, [
     EncryptedSecretType.LOGIN_CREDENTIALS
@@ -260,6 +267,41 @@ export const AuthsList = ({
       {hasNoSecrets ? (
         <div className="px-2 py-3 text-sm text-[color:var(--color-muted)]">
           Start by adding a login secret or TOTP code
+        </div>
+      ) : null}
+
+      {filterByTLD &&
+      currentURL &&
+      matchingWebInputsForCurrentPage.length > 0 ? (
+        <div className="mt-2 px-2 pb-2">
+          <Button
+            className="w-full"
+            variant="outline"
+            onClick={async () => {
+              await Promise.all(
+                matchingWebInputsForCurrentPage.map(({ id }) =>
+                  removeWebInput({
+                    variables: {
+                      id
+                    }
+                  })
+                )
+              )
+
+              const removedIds = new Set(
+                matchingWebInputsForCurrentPage.map(({ id }) => id)
+              )
+
+              const remainingWebInputs =
+                device.state?.webInputs.filter((webInput) => {
+                  return !removedIds.has(webInput.id)
+                }) ?? []
+
+              device.setWebInputs(remainingWebInputs)
+            }}
+          >
+            {t`Remove saved autofill inputs for this page`}
+          </Button>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
### Motivation
- Provide a quick way in the AuthsList UI to remove saved autofill/web input entries associated with the currently viewed page or domain.
- Keep the extension background `device` state in sync after removing entries so the UI reflects the change immediately.

### Description
- Import `useRemoveWebInputMutation`, `device`, and `getWebInputsForUrl`, and wire up `const [removeWebInput] = useRemoveWebInputMutation()` in `AuthsList`.
- Compute `matchingWebInputsForCurrentPage` using `getWebInputsForUrl(currentURL)` and render a full-width outline `Button` when `filterByTLD`, `currentURL`, and matches exist.
- Button click handler calls `removeWebInput` for each matching `id` via `Promise.all`, then filters out removed entries from `device.state?.webInputs` and updates the background with `device.setWebInputs(remainingWebInputs)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e83c181c83329e0ba3f7c597b8ae)