### PR TITLE
Add ability to list and remove matched web inputs in AuthsList

### DIFF
--- a/web-extension/src/components/pages/AuthsList.tsx
+++ b/web-extension/src/components/pages/AuthsList.tsx
@@ -16,6 +16,10 @@ import { getDomainNameAndTldFromUrl } from '@shared/urlUtils'
 import { EncryptedSecretType } from '@shared/generated/graphqlBaseTypes'
 import { PopupActionsEnum } from './PopupActionsEnum'
 import { SquareMousePointer } from './SquareMousePointerIcon'
+import { useRemoveWebInputMutation } from '../vault/VaultItemSettings.codegen'
+import { device } from '@src/background/ExtensionDevice'
+import { getWebInputsForUrl } from '@src/background/getWebInputsForUrl'
+import type { WebInputForAutofill } from '@src/background/WebInputForAutofill'
 
 const log = debug('au:AuthsList')
 
@@ -178,6 +182,7 @@ export const AuthsList = ({
     currentURL,
     searchSecrets
   } = useContext(DeviceStateContext)
+  const [removeWebInput] = useRemoveWebInputMutation()
 
   if (!deviceState) {
     return null
@@ -212,6 +217,24 @@ export const AuthsList = ({
   )
 
   const hasNoSecrets = deviceState.secrets.length === 0
+  const matchingWebInputsForCurrentPage = currentURL
+    ? getWebInputsForUrl(currentURL)
+    : []
+
+  const removeOneWebInput = async (webInput: WebInputForAutofill) => {
+    await removeWebInput({
+      variables: {
+        id: webInput.id
+      }
+    })
+
+    const remainingWebInputs =
+      device.state?.webInputs.filter((savedWebInput) => {
+        return savedWebInput.id !== webInput.id
+      }) ?? []
+
+    device.setWebInputs(remainingWebInputs)
+  }
   const totps = searchSecrets(search, [EncryptedSecretType.TOTP]) as ITOTPSecret[]
   const creds = searchSecrets(search, [
     EncryptedSecretType.LOGIN_CREDENTIALS
@@ -260,6 +283,34 @@ export const AuthsList = ({
       {hasNoSecrets ? (
         <div className="px-2 py-3 text-sm text-[color:var(--color-muted)]">
           Start by adding a login secret or TOTP code
+        </div>
+      ) : null}
+
+      {filterByTLD &&
+      currentURL &&
+      matchingWebInputsForCurrentPage.length > 0 ? (
+        <div className="mt-2 px-2 pb-2">
+          <div className="mb-2 text-xs text-[color:var(--color-muted)]">
+            {t`Remove matched web input`}
+          </div>
+
+          <div className="grid gap-2">
+            {matchingWebInputsForCurrentPage.map((webInput) => (
+              <Button
+                className="w-full justify-between gap-2"
+                key={webInput.id}
+                variant="outline"
+                onClick={async () => {
+                  await removeOneWebInput(webInput)
+                }}
+              >
+                <span className="truncate text-left text-xs">
+                  {webInput.kind}: {webInput.domPath}
+                </span>
+                <span className="shrink-0">{t`Remove`}</span>
+              </Button>
+            ))}
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
### Motivation

- Expose saved web input matches for the current page in the auths list so users can remove unwanted autofill targets. 
- Keep the extension background device state in sync after a server-side removal.

### Description

- Added `useRemoveWebInputMutation`, `getWebInputsForUrl`, and `device` imports and a `matchingWebInputsForCurrentPage` computed list using `getWebInputsForUrl(currentURL)`.
- Implemented `removeOneWebInput` which calls the `removeWebInput` GraphQL mutation and then updates `device.setWebInputs` to remove the deleted input from local state.
- Rendered a new UI block when `filterByTLD` and `currentURL` are set that lists matched `webInput` items with an on-click `Remove` `Button` that invokes `removeOneWebInput`.
- Kept existing TOTP and login credential rendering intact and only conditionally show the web-input removal UI when matches exist.

### Testing

- Ran the TypeScript type-check/build pipeline which completed successfully.
- Executed the test suite and linters; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e83c181c83329e0ba3f7c597b8ae)