### PR TITLE
Scope web-input deletion rate limits to free users and require 1-week account age

### DIFF
--- a/backend/models/UserMutation.ts
+++ b/backend/models/UserMutation.ts
@@ -33,6 +33,7 @@ import debug from 'debug'
 import { setNewAccessTokenIntoCookie, setNewRefreshToken } from '../userAuth'
 import { DefaultDeviceSettingsMutation } from './DefaultDeviceSettings'
 import { defaultDeviceSettingSystemValues } from './defaultDeviceSettingSystemValues'
+import { defaultAccountLimits } from './accountLimits'
 import { UserNewDevicePolicyGQL } from './types/UserNewDevicePolicy'
 import { eq, and, sql, inArray, isNull, count } from 'drizzle-orm'
 import {
@@ -180,8 +181,10 @@ export class UserMutation extends UserBase {
       where: { id: ctx.jwtPayload.userId }
     })
 
-    const pswLimit = userData?.loginCredentialsLimit ?? 40
-    const TOTPLimit = userData?.TOTPlimit ?? 3
+    const pswLimit =
+      userData?.loginCredentialsLimit ??
+      defaultAccountLimits.loginCredentialsLimit
+    const TOTPLimit = userData?.TOTPlimit ?? defaultAccountLimits.TOTPlimit
 
     let [{ count: pswCount }] = await ctx.db
       .select({ count: count() })

--- a/backend/models/WebInput.spec.ts
+++ b/backend/models/WebInput.spec.ts
@@ -1,0 +1,129 @@
+import { plainToClass } from 'class-transformer'
+import { eq } from 'drizzle-orm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { db } from '../prisma/prismaClient'
+import { RedisBasicRateLimiter } from '../lib/RedisBasicRateLimiter'
+import * as schema from '../drizzle/schema'
+import {
+  defaultAccountLimits,
+  webInputRemovalMinimumAccountAgeMs
+} from './accountLimits'
+import { WebInputMutation } from './WebInput'
+
+const insertedUserIds: string[] = []
+const insertedWebInputIds: number[] = []
+
+const insertUser = async (
+  overrides: Partial<typeof schema.user.$inferInsert> = {}
+) => {
+  const [user] = await db
+    .insert(schema.user)
+    .values({
+      id: crypto.randomUUID(),
+      email: `${crypto.randomUUID()}@test.com`,
+      addDeviceSecret: crypto.randomUUID(),
+      addDeviceSecretEncrypted: crypto.randomUUID(),
+      encryptionSalt: crypto.randomUUID(),
+      deviceRecoveryCooldownMinutes: 960,
+      ...defaultAccountLimits,
+      ...overrides
+    })
+    .returning()
+
+  insertedUserIds.push(user.id)
+
+  return user
+}
+
+const insertWebInput = async (addedByUserId: string | null) => {
+  const [input] = await db
+    .insert(schema.webInput)
+    .values({
+      url: `https://${crypto.randomUUID()}.example.com/login`,
+      kind: 'USERNAME',
+      domPath: `#${crypto.randomUUID()}`,
+      host: 'example.com',
+      addedByUserId
+    })
+    .returning()
+
+  insertedWebInputIds.push(input.id)
+
+  return plainToClass(WebInputMutation, input)
+}
+
+const makeCtx = (userId: string) =>
+  ({
+    db,
+    jwtPayload: { userId }
+  }) as Parameters<WebInputMutation['delete']>[0]
+
+describe('WebInputMutation', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks()
+
+    for (const id of insertedWebInputIds.splice(0)) {
+      await db.delete(schema.webInput).where(eq(schema.webInput.id, id))
+    }
+
+    for (const id of insertedUserIds.splice(0)) {
+      await db.delete(schema.user).where(eq(schema.user.id, id))
+    }
+  })
+
+  it('prohibits removing web inputs from accounts newer than one week', async () => {
+    const user = await insertUser()
+    const input = await insertWebInput(null)
+
+    await expect(input.delete(makeCtx(user.id))).rejects.toThrow(
+      'You can remove saved autofill inputs after your account is at least 1 week old.'
+    )
+  })
+
+  it('rate limits default-limit users removing web inputs added by others', async () => {
+    const user = await insertUser({
+      createdAt: new Date(Date.now() - webInputRemovalMinimumAccountAgeMs)
+    })
+    const input = await insertWebInput(null)
+    const increment = vi
+      .spyOn(RedisBasicRateLimiter.prototype, 'increment')
+      .mockResolvedValue(undefined)
+
+    await input.delete(makeCtx(user.id))
+
+    expect(increment).toHaveBeenCalledWith(user.id)
+  })
+
+  it('does not rate limit users with higher than default account limits', async () => {
+    const user = await insertUser({
+      createdAt: new Date(Date.now() - webInputRemovalMinimumAccountAgeMs),
+      loginCredentialsLimit: defaultAccountLimits.loginCredentialsLimit + 1
+    })
+    const input = await insertWebInput(null)
+    const increment = vi
+      .spyOn(RedisBasicRateLimiter.prototype, 'increment')
+      .mockResolvedValue(undefined)
+
+    await input.delete(makeCtx(user.id))
+
+    expect(increment).not.toHaveBeenCalled()
+    const deleted = await db.query.webInput.findFirst({
+      where: { id: input.id }
+    })
+    expect(deleted).toBeUndefined()
+  })
+
+  it('does not rate limit users removing their own web inputs', async () => {
+    const user = await insertUser({
+      createdAt: new Date(Date.now() - webInputRemovalMinimumAccountAgeMs)
+    })
+    const input = await insertWebInput(user.id)
+    const increment = vi
+      .spyOn(RedisBasicRateLimiter.prototype, 'increment')
+      .mockResolvedValue(undefined)
+
+    await input.delete(makeCtx(user.id))
+
+    expect(increment).not.toHaveBeenCalled()
+  })
+})

--- a/backend/models/WebInput.ts
+++ b/backend/models/WebInput.ts
@@ -6,6 +6,11 @@ import { RedisBasicRateLimiter } from '../lib/RedisBasicRateLimiter'
 import { redisClient } from '../lib/redisClient'
 import { webInput } from '../drizzle/schema'
 import { eq } from 'drizzle-orm'
+import { GraphqlError } from '../lib/GraphqlError'
+import {
+  isOldEnoughToRemoveWebInputs,
+  shouldApplyFreeUserRateLimit
+} from './accountLimits'
 
 const log = debug('au:WebInput')
 
@@ -19,8 +24,27 @@ const rateLimiter = new RedisBasicRateLimiter(redisClient, {
 export class WebInputMutation extends WebInputGQL {
   @Field(() => WebInputGQLScalars, { nullable: true })
   async delete(@Ctx() ctx: IContextAuthenticated) {
+    const deletingUser = await ctx.db.query.user.findFirst({
+      where: { id: ctx.jwtPayload.userId },
+      columns: {
+        createdAt: true,
+        loginCredentialsLimit: true,
+        TOTPlimit: true
+      }
+    })
+
+    if (!deletingUser) {
+      throw new GraphqlError('User not found')
+    }
+
+    if (!isOldEnoughToRemoveWebInputs(deletingUser)) {
+      throw new GraphqlError(
+        'You can remove saved autofill inputs after your account is at least 1 week old.'
+      )
+    }
+
     const isSameUser = ctx.jwtPayload.userId === this.addedByUserId
-    if (!isSameUser) {
+    if (!isSameUser && shouldApplyFreeUserRateLimit(deletingUser)) {
       await rateLimiter.increment(ctx.jwtPayload.userId)
     }
     const res = await ctx.db

--- a/backend/models/accountLimits.spec.ts
+++ b/backend/models/accountLimits.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultAccountLimits,
+  isOldEnoughToRemoveWebInputs,
+  shouldApplyFreeUserRateLimit,
+  webInputRemovalMinimumAccountAgeMs
+} from './accountLimits'
+
+describe('accountLimits', () => {
+  it('applies web input delete rate limits to default-limit users', () => {
+    expect(shouldApplyFreeUserRateLimit(defaultAccountLimits)).toBe(true)
+  })
+
+  it('skips web input delete rate limits for users above default account limits', () => {
+    expect(
+      shouldApplyFreeUserRateLimit({
+        ...defaultAccountLimits,
+        loginCredentialsLimit: defaultAccountLimits.loginCredentialsLimit + 1
+      })
+    ).toBe(false)
+    expect(
+      shouldApplyFreeUserRateLimit({
+        ...defaultAccountLimits,
+        TOTPlimit: defaultAccountLimits.TOTPlimit + 1
+      })
+    ).toBe(false)
+  })
+
+  it('allows web input removal only once the account is at least a week old', () => {
+    const now = new Date('2026-05-07T00:00:00.000Z')
+
+    expect(
+      isOldEnoughToRemoveWebInputs(
+        {
+          createdAt: new Date(
+            now.getTime() - webInputRemovalMinimumAccountAgeMs
+          )
+        },
+        now
+      )
+    ).toBe(true)
+
+    expect(
+      isOldEnoughToRemoveWebInputs(
+        {
+          createdAt: new Date(
+            now.getTime() - webInputRemovalMinimumAccountAgeMs + 1
+          )
+        },
+        now
+      )
+    ).toBe(false)
+  })
+})

--- a/backend/models/accountLimits.ts
+++ b/backend/models/accountLimits.ts
@@ -1,0 +1,28 @@
+export const defaultAccountLimits = {
+  loginCredentialsLimit: 40,
+  TOTPlimit: 3
+} as const
+
+export const webInputRemovalMinimumAccountAgeMs = 7 * 24 * 60 * 60 * 1000
+
+export type AccountLimitUser = {
+  loginCredentialsLimit: number
+  TOTPlimit: number
+}
+
+export type AccountAgeUser = {
+  createdAt: Date
+}
+
+export const hasHigherThanDefaultAccountLimits = (user: AccountLimitUser) =>
+  user.loginCredentialsLimit > defaultAccountLimits.loginCredentialsLimit ||
+  user.TOTPlimit > defaultAccountLimits.TOTPlimit
+
+export const shouldApplyFreeUserRateLimit = (user: AccountLimitUser) =>
+  !hasHigherThanDefaultAccountLimits(user)
+
+export const isOldEnoughToRemoveWebInputs = (
+  user: AccountAgeUser,
+  now = new Date()
+) =>
+  now.getTime() - user.createdAt.getTime() >= webInputRemovalMinimumAccountAgeMs

--- a/backend/schemas/RootResolver.ts
+++ b/backend/schemas/RootResolver.ts
@@ -54,6 +54,7 @@ import type {
 import { eq, and, or, like, sql, gte, count, isNull, desc } from 'drizzle-orm'
 import * as schema from '../drizzle/schema'
 import { createHash } from 'crypto'
+import { defaultAccountLimits } from '../models/accountLimits'
 
 const log = debug('au:RootResolver')
 
@@ -249,8 +250,8 @@ export class RootResolver {
           addDeviceSecretEncrypted,
           encryptionSalt,
           deviceRecoveryCooldownMinutes: 16 * 60,
-          loginCredentialsLimit: 40,
-          TOTPlimit: 3
+          loginCredentialsLimit: defaultAccountLimits.loginCredentialsLimit,
+          TOTPlimit: defaultAccountLimits.TOTPlimit
         })
         .returning()
 


### PR DESCRIPTION
### Motivation
- Prevent abuse and avoid rate-limiting paid users by applying the web-input deletion Redis rate limit only to free/default-limit accounts. 
- Disallow removal of saved autofill inputs from accounts that are newer than one week to avoid accidental/abusive deletions from very fresh accounts.

### Description
- Added `backend/models/accountLimits.ts` providing `defaultAccountLimits`, `webInputRemovalMinimumAccountAgeMs`, and helpers `shouldApplyFreeUserRateLimit` and `isOldEnoughToRemoveWebInputs` to centralize account-limit logic.  
- Updated `backend/models/WebInput.ts` to fetch the deleting user, enforce the one-week account-age guard, and call the Redis deletion rate limiter only when `shouldApplyFreeUserRateLimit(user)` is true and the remover is not the original adder.  
- Reused `defaultAccountLimits` in `backend/schemas/RootResolver.ts` and `backend/models/UserMutation.ts` for registration/default fallbacks so limits are centralized.  
- Added tests `backend/models/accountLimits.spec.ts` and `backend/models/WebInput.spec.ts` exercising the helpers and the new deletion guards and behaviors.

### Testing
- Ran `cd backend && pnpm vitest run models/accountLimits.spec.ts models/WebInput.spec.ts`, and both specs passed.  
- Ran typecheck with `cd backend && pnpm tsc` and formatting check with `pnpm fmt:check ...` and both succeeded.  
- Ran full backend test suite `cd backend && pnpm test`, which failed due to test environment limitations (missing Upstash Redis `url`/`token`, missing `STRIPE_SECRET_KEY`, and an existing oRPC test timeout) unrelated to the new logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9203a9f08332a75654829ce6cf32)