### PR TITLE
Add popup toggle to disable credential autofill/auto-submit

### DIFF
--- a/web-extension/src/pages/Home.tsx
+++ b/web-extension/src/pages/Home.tsx
@@ -16,7 +16,7 @@ const getTotpTimeRemaining = () => {
 export const Home = () => {
   const [seconds, setRemainingSeconds] = useState(getTotpTimeRemaining())
   const [search, setSearch] = useState('')
-  const { currentURL, deviceState, TOTPSecrets } =
+  const { currentURL, deviceState, setSecuritySettings, TOTPSecrets } =
     useContext(DeviceStateContext)
 
   useEffect(() => {
@@ -74,6 +74,35 @@ export const Home = () => {
           />
         ) : null}
       </div>
+
+      {deviceState ? (
+        <div className="mt-3 px-2">
+          <label className="flex items-center justify-between rounded-[var(--radius-md)] border border-[color:var(--color-border)] bg-[color:var(--color-card)] px-3 py-2 text-sm text-[color:var(--color-foreground)]">
+            <div className="pr-3">
+              <div className="font-medium">Autofill login forms</div>
+              <div className="text-xs text-[color:var(--color-muted)]">
+                Auto-fills credentials and may submit detected login forms.
+              </div>
+            </div>
+            <Switch
+              checked={deviceState.autofillCredentialsEnabled}
+              onCheckedChange={(checked) => {
+                setSecuritySettings({
+                  autofillCredentialsEnabled: checked,
+                  autofillTOTPEnabled: deviceState.autofillTOTPEnabled,
+                  notificationOnVaultUnlock:
+                    deviceState.notificationOnVaultUnlock,
+                  notificationOnWrongPasswordAttempts:
+                    deviceState.notificationOnWrongPasswordAttempts,
+                  syncTOTP: deviceState.syncTOTP,
+                  uiLanguage: deviceState.uiLanguage,
+                  vaultLockTimeoutSeconds: deviceState.vaultLockTimeoutSeconds
+                })
+              }}
+            />
+          </label>
+        </div>
+      ) : null}
 
       <div className="mt-2 h-[300px] w-[350px] px-1">
         <div className="grid gap-3 pb-5">


### PR DESCRIPTION
### Motivation
- Provide a quick way in the extension popup to disable credential autofill (and the auto-submit behavior that can trigger on some sites) to avoid unwanted form submissions and broken site interactions.

### Description
- Add a small toggle UI to the popup `Home` view (`web-extension/src/pages/Home.tsx`) that displays the current `autofillCredentialsEnabled` state and calls the existing `setSecuritySettings(...)` context function to persist changes immediately.

### Testing
- Ran TypeScript type checking for the web extension with `pnpm --dir web-extension tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ecd486d083328a8f389e600bbf77)