### PR TITLE
Move autofill control to browser preferences

### DIFF
--- a/backend/drizzle/migrations/20260728111829_robust_riptide/migration.sql
+++ b/backend/drizzle/migrations/20260728111829_robust_riptide/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "User" ADD COLUMN "autofillForbiddenUrlPatterns" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "DefaultSettings" DROP COLUMN "autofillCredentialsEnabled";--> statement-breakpoint
+ALTER TABLE "Device" DROP COLUMN "autofillCredentialsEnabled";

--- a/backend/drizzle/migrations/20260728111829_robust_riptide/snapshot.json
+++ b/backend/drizzle/migrations/20260728111829_robust_riptide/snapshot.json
@@ -1,0 +1,2959 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "3c89066f-abda-412b-8551-65bfc04017ed",
+  "prevIds": [
+    "3eda485f-13ce-4dda-8d75-a88f277b6e59"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "PRIMARY",
+        "CONTACT"
+      ],
+      "name": "EmailVerificationType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "TOTP",
+        "LOGIN_CREDENTIALS"
+      ],
+      "name": "EncryptedSecretType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "EMAIL",
+        "API"
+      ],
+      "name": "TokenType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "ALLOW",
+        "REQUIRE_ANY_DEVICE_APPROVAL",
+        "REQUIRE_MASTER_DEVICE_APPROVAL"
+      ],
+      "name": "UserNewDevicePolicy",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "TOTP",
+        "USERNAME",
+        "EMAIL",
+        "USERNAME_OR_EMAIL",
+        "PASSWORD",
+        "NEW_PASSWORD",
+        "NEW_PASSWORD_CONFIRMATION",
+        "SUBMIT_BUTTON",
+        "CUSTOM"
+      ],
+      "name": "WebInputType",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "DecryptionChallenge",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "DefaultSettings",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "Device",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "EmailVerification",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "EncryptedSecret",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "MasterDeviceChange",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "MasterDeviceResetRequest",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "_prisma_migrations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "SecretUsageEvent",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "Tag",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "Token",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "User",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "UserPaidProducts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "WebInput",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ipAddress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "approvedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "approvedFromDeviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "masterPasswordVerifiedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "blockIp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rejectedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "approvedByRecovery",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deviceName",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "pushNotificationsSentCount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "pushNotificationsFailedCount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "autofillTOTPEnabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "86400",
+      "generated": null,
+      "identity": null,
+      "name": "vaultLockTimeoutSeconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "syncTOTP",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'dark'",
+      "generated": null,
+      "identity": null,
+      "name": "theme",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "firstIpAddress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastIpAddress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "firebaseToken",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "ipAddressLock",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vaultLockTimeoutSeconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "registeredWithMasterAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastSyncAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "masterPasswordOutdatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logoutAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastLockAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lastUnlockAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "syncTOTP",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deletedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "autofillTOTPEnabled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "EmailVerificationType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "verifiedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encrypted",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "EncryptedSecretType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deletedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "processAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "oldDeviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "newDeviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "processAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "confirmedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rejectedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "confirmationTokenHash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "targetMasterDeviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "decryptionChallengeId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "type": "varchar(36)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "migration_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logs",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rolled_back_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "applied_steps_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "_prisma_migrations"
+    },
+    {
+      "type": "bigserial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ipAddress",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "webInputId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secretId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "TokenType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailToken",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "valid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expiration",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "tokenVersion",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "addDeviceSecret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "addDeviceSecretEncrypted",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "masterDeviceId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "TOTPlimit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "loginCredentialsLimit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encryptionSalt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deviceRecoveryCooldownMinutes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "recoveryDecryptionChallengeId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "notificationOnVaultUnlock",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "3",
+      "generated": null,
+      "identity": null,
+      "name": "notificationOnWrongPasswordAttempts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'en'",
+      "generated": null,
+      "identity": null,
+      "name": "uiLanguage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "autofillForbiddenUrlPatterns",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "UserNewDevicePolicy",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "newDevicePolicy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expiresAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "productId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checkoutSessionId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "layoutType",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "timestamp(3)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "CURRENT_TIMESTAMP",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "WebInputType",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "domPath",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "addedByUserId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "varchar(253)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "domOrdinal",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "deviceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "DecryptionChallenge_deviceId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "DecryptionChallenge_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "DefaultSettings_userId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "firebaseToken",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Device_firebaseToken_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lastSyncAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Device_lastSyncAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updatedAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Device_updatedAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Device_userId_id_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "EmailVerification_token_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "EmailVerification_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "EncryptedSecret_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "decryptionChallengeId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "MasterDeviceResetRequest_decryptionChallengeId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "MasterDeviceResetRequest_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "processAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "MasterDeviceResetRequest_processAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "confirmationTokenHash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "MasterDeviceResetRequest_confirmationTokenHash_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "expiresAt",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "MasterDeviceResetRequest_expiresAt_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secretId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "SecretUsageEvent_secretId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Tag_userId_name_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "emailToken",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Token_emailToken_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "Token_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "User_email_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "masterDeviceId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "User_masterDeviceId_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "username",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "User_username_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "userId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "UserPaidProducts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "host",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "WebInput_host_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "WebInput_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "url",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "domPath",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "WebInput_url_domPath_key",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "DecryptionChallenge_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "approvedFromDeviceId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "Device",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "DecryptionChallenge_approvedFromDeviceId_Device_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "DecryptionChallenge"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "DefaultSettings_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "DefaultSettings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "Device_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "Device"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "EmailVerification_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "EmailVerification"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "EncryptedSecret_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "EncryptedSecret"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "MasterDeviceChange_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "MasterDeviceChange"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "decryptionChallengeId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "DecryptionChallenge",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "MasterDeviceResetRequest_HvFB3D6sZNJH_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "MasterDeviceResetRequest_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "SecretUsageEvent_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "deviceId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "Device",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "SecretUsageEvent_deviceId_Device_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "webInputId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "WebInput",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "SecretUsageEvent_webInputId_WebInput_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "secretId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "EncryptedSecret",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "SecretUsageEvent_secretId_EncryptedSecret_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "SecretUsageEvent"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "Tag_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "Tag"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "Token_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "Token"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "masterDeviceId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "Device",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "User_masterDeviceId_Device_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "recoveryDecryptionChallengeId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "DecryptionChallenge",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "User_recoveryDecryptionChallengeId_DecryptionChallenge_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "User"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "UserPaidProducts_userId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "UserPaidProducts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "addedByUserId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "User",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "WebInput_addedByUserId_User_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "WebInput"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "DecryptionChallenge_pkey",
+      "schema": "public",
+      "table": "DecryptionChallenge",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "DefaultSettings_pkey",
+      "schema": "public",
+      "table": "DefaultSettings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Device_pkey",
+      "schema": "public",
+      "table": "Device",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "address"
+      ],
+      "nameExplicit": false,
+      "name": "EmailVerification_pkey",
+      "schema": "public",
+      "table": "EmailVerification",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "EncryptedSecret_pkey",
+      "schema": "public",
+      "table": "EncryptedSecret",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "MasterDeviceChange_pkey",
+      "schema": "public",
+      "table": "MasterDeviceChange",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "MasterDeviceResetRequest_pkey",
+      "schema": "public",
+      "table": "MasterDeviceResetRequest",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "_prisma_migrations_pkey",
+      "schema": "public",
+      "table": "_prisma_migrations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "SecretUsageEvent_pkey",
+      "schema": "public",
+      "table": "SecretUsageEvent",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Tag_pkey",
+      "schema": "public",
+      "table": "Tag",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Token_pkey",
+      "schema": "public",
+      "table": "Token",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "User_pkey",
+      "schema": "public",
+      "table": "User",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "UserPaidProducts_pkey",
+      "schema": "public",
+      "table": "UserPaidProducts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "WebInput_pkey",
+      "schema": "public",
+      "table": "WebInput",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/backend/drizzle/migrations/base.sql
+++ b/backend/drizzle/migrations/base.sql
@@ -31,7 +31,6 @@ CREATE TABLE "DefaultSettings" (
 	"id" serial PRIMARY KEY,
 	"createdAt" timestamp(3) DEFAULT CURRENT_TIMESTAMP NOT NULL,
 	"updatedAt" timestamp(3),
-	"autofillCredentialsEnabled" boolean DEFAULT true NOT NULL,
 	"autofillTOTPEnabled" boolean DEFAULT true NOT NULL,
 	"vaultLockTimeoutSeconds" integer DEFAULT 86400 NOT NULL,
 	"userId" uuid NOT NULL,
@@ -59,7 +58,6 @@ CREATE TABLE "Device" (
 	"lastUnlockAt" timestamp(3),
 	"syncTOTP" boolean NOT NULL,
 	"deletedAt" timestamp(3),
-	"autofillCredentialsEnabled" boolean NOT NULL,
 	"autofillTOTPEnabled" boolean NOT NULL
 );
 --> statement-breakpoint
@@ -154,6 +152,7 @@ CREATE TABLE "User" (
 	"notificationOnVaultUnlock" boolean DEFAULT false NOT NULL,
 	"notificationOnWrongPasswordAttempts" integer DEFAULT 3 NOT NULL,
 	"uiLanguage" text DEFAULT 'en' NOT NULL,
+	"autofillForbiddenUrlPatterns" text DEFAULT '' NOT NULL,
 	"newDevicePolicy" "UserNewDevicePolicy"
 );
 --> statement-breakpoint

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -106,7 +106,6 @@ export const defaultSettings = pgTable(
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
     updatedAt: timestamp({ precision: 3 }),
-    autofillCredentialsEnabled: boolean().default(true).notNull(),
     autofillTOTPEnabled: boolean().default(true).notNull(),
     vaultLockTimeoutSeconds: integer().default(86400).notNull(),
     userId: uuid()
@@ -152,7 +151,6 @@ export const device = pgTable(
     lastUnlockAt: timestamp({ precision: 3 }),
     syncTOTP: boolean().notNull(),
     deletedAt: timestamp({ precision: 3 }),
-    autofillCredentialsEnabled: boolean().notNull(),
     autofillTOTPEnabled: boolean().notNull()
   },
   (table) => [
@@ -404,6 +402,7 @@ export const user = pgTable(
     notificationOnVaultUnlock: boolean().default(false).notNull(),
     notificationOnWrongPasswordAttempts: integer().default(3).notNull(),
     uiLanguage: text().default('en').notNull(),
+    autofillForbiddenUrlPatterns: text().default('').notNull(),
     newDevicePolicy: userNewDevicePolicy()
   },
   (table) => [

--- a/backend/gqlSchemas/authier.graphql
+++ b/backend/gqlSchemas/authier.graphql
@@ -31,6 +31,7 @@ type UserQuery {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   newDevicePolicy: UserNewDevicePolicy
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
@@ -106,6 +107,7 @@ type UserGQL {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   newDevicePolicy: UserNewDevicePolicy
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
@@ -132,7 +134,6 @@ type DeviceGQL {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -263,7 +264,6 @@ type DefaultDeviceSettingsGQL {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -283,7 +283,6 @@ type DeviceQuery {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -327,7 +326,6 @@ type DefaultDeviceSettingsQuery {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -442,6 +440,7 @@ type UserMutation {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   newDevicePolicy: UserNewDevicePolicy
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
@@ -501,7 +500,6 @@ type DeviceMutation {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -559,7 +557,6 @@ type DefaultDeviceSettingsMutation {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -572,7 +569,6 @@ type DefaultDeviceSettingsGQLScalars {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -583,7 +579,6 @@ type DefaultDeviceSettingsGQLScalars {
 input DefaultSettingsInput {
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   uiLanguage: String!
   theme: String!
@@ -625,8 +620,8 @@ input SecretUsageEventInput {
 input SettingsInput {
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
+  autofillForbiddenUrlPatterns: String
   uiLanguage: String!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!

--- a/backend/models/DecryptionChallenge.ts
+++ b/backend/models/DecryptionChallenge.ts
@@ -187,8 +187,6 @@ export class DecryptionChallengeApproved extends DecryptionChallengeGQL {
           userId: userData.id,
           platform: input.devicePlatform,
           syncTOTP: defaultSettings.syncTOTP,
-          autofillCredentialsEnabled:
-            defaultSettings.autofillCredentialsEnabled,
           autofillTOTPEnabled: defaultSettings.autofillTOTPEnabled,
           vaultLockTimeoutSeconds: defaultSettings.vaultLockTimeoutSeconds
         })

--- a/backend/models/DefaultDeviceSettings.ts
+++ b/backend/models/DefaultDeviceSettings.ts
@@ -26,7 +26,6 @@ export class DefaultDeviceSettingsMutation extends DefaultDeviceSettingsGQLScala
       autofillTOTPEnabled: config.autofillTOTPEnabled,
       syncTOTP: config.syncTOTP,
       vaultLockTimeoutSeconds: config.vaultLockTimeoutSeconds,
-      autofillCredentialsEnabled: config.autofillCredentialsEnabled,
       theme: config.theme
     }
 

--- a/backend/models/UserMutation.spec.ts
+++ b/backend/models/UserMutation.spec.ts
@@ -155,21 +155,21 @@ describe('UserMutation', () => {
         syncTOTP: true,
         vaultLockTimeoutSeconds: 3600,
         uiLanguage: 'cs',
-        autofillCredentialsEnabled: false,
         autofillTOTPEnabled: false,
+        autofillForbiddenUrlPatterns:
+          'www.google.com/my-path/*\nhttps://internal.test/*',
         notificationOnVaultUnlock: false,
         notificationOnWrongPasswordAttempts: 3
       }
 
-      const res = await user.updateSettings(
-        newSettings,
-        makeFakeCtx({
-          userId: user.id,
-          device: {
-            id: masterDeviceId
-          } as Parameters<typeof makeFakeCtx>[0]['device']
-        })
-      )
+      const ctx = makeFakeCtx({
+        userId: user.id,
+        device: {
+          id: masterDeviceId
+        } as Parameters<typeof makeFakeCtx>[0]['device']
+      })
+
+      const res = await user.updateSettings(newSettings, ctx)
 
       const deviceData = await db.query.device.findFirst({
         where: { id: masterDeviceId }
@@ -180,6 +180,25 @@ describe('UserMutation', () => {
         newSettings.vaultLockTimeoutSeconds
       )
       expect(deviceData?.syncTOTP).toBe(newSettings.syncTOTP)
+      expect(res.autofillForbiddenUrlPatterns).toBe(
+        newSettings.autofillForbiddenUrlPatterns
+      )
+
+      const {
+        autofillForbiddenUrlPatterns: omittedAutofillForbiddenUrlPatterns,
+        ...legacySettings
+      } = newSettings
+      expect(omittedAutofillForbiddenUrlPatterns).toBeDefined()
+
+      const userWithUpdatedSettings = plainToClass(UserMutation, res)
+      await userWithUpdatedSettings.updateSettings(legacySettings, ctx)
+
+      const userDataAfterLegacyUpdate = await db.query.user.findFirst({
+        where: { id: user.id }
+      })
+      expect(userDataAfterLegacyUpdate?.autofillForbiddenUrlPatterns).toBe(
+        newSettings.autofillForbiddenUrlPatterns
+      )
     })
   })
 

--- a/backend/models/UserMutation.ts
+++ b/backend/models/UserMutation.ts
@@ -109,8 +109,6 @@ export class UserMutation extends UserBase {
         userId: this.id,
         lastIpAddress: ipAddress,
         vaultLockTimeoutSeconds: deviceDefaultSettings.vaultLockTimeoutSeconds,
-        autofillCredentialsEnabled:
-          deviceDefaultSettings.autofillCredentialsEnabled,
         autofillTOTPEnabled: deviceDefaultSettings.autofillTOTPEnabled,
         syncTOTP: deviceDefaultSettings.syncTOTP
       })
@@ -272,7 +270,6 @@ export class UserMutation extends UserBase {
       .set({
         syncTOTP: config.syncTOTP,
         vaultLockTimeoutSeconds: config.vaultLockTimeoutSeconds,
-        autofillCredentialsEnabled: config.autofillCredentialsEnabled,
         autofillTOTPEnabled: config.autofillTOTPEnabled
       })
       .where(eq(deviceSchema.id, ctx.device.id))
@@ -282,6 +279,9 @@ export class UserMutation extends UserBase {
       .set({
         notificationOnVaultUnlock: config.notificationOnVaultUnlock,
         uiLanguage: config.uiLanguage,
+        autofillForbiddenUrlPatterns:
+          config.autofillForbiddenUrlPatterns ??
+          this.autofillForbiddenUrlPatterns,
         notificationOnWrongPasswordAttempts:
           config.notificationOnWrongPasswordAttempts
       })

--- a/backend/models/defaultDeviceSettingSystemValues.ts
+++ b/backend/models/defaultDeviceSettingSystemValues.ts
@@ -1,14 +1,12 @@
 export const defaultDeviceSettingSystemValues = {
   vaultLockTimeoutSeconds: 28800,
   autofillTOTPEnabled: true,
-  autofillCredentialsEnabled: true,
   syncTOTP: true
 }
 
 export const defaultDeviceSettingUserValuesWithId = {
   vaultLockTimeoutSeconds: 28800,
   autofillTOTPEnabled: true,
-  autofillCredentialsEnabled: true,
   syncTOTP: true,
   theme: 'dark',
   id: 0

--- a/backend/models/generated/DefaultDeviceSettingsGQL.ts
+++ b/backend/models/generated/DefaultDeviceSettingsGQL.ts
@@ -13,9 +13,6 @@ export class DefaultDeviceSettingsGQLScalars {
   updatedAt: Date | null
 
   @Field(() => Boolean)
-  autofillCredentialsEnabled: boolean
-
-  @Field(() => Boolean)
   autofillTOTPEnabled: boolean
 
   @Field(() => String)

--- a/backend/models/generated/DeviceGQL.ts
+++ b/backend/models/generated/DeviceGQL.ts
@@ -36,9 +36,6 @@ export class DeviceGQLScalars {
   vaultLockTimeoutSeconds: number
 
   @Field(() => Boolean)
-  autofillCredentialsEnabled: boolean
-
-  @Field(() => Boolean)
   autofillTOTPEnabled: boolean
 
   @Field(() => GraphQLISODateTime)

--- a/backend/models/generated/UserGQL.ts
+++ b/backend/models/generated/UserGQL.ts
@@ -55,6 +55,9 @@ export class UserGQLScalars {
   @Field(() => Int)
   notificationOnWrongPasswordAttempts: number
 
+  @Field(() => String)
+  autofillForbiddenUrlPatterns: string
+
   @Field(() => UserNewDevicePolicyGQL, { nullable: true })
   newDevicePolicy: UserNewDevicePolicyGQL | null
 }

--- a/backend/models/models.ts
+++ b/backend/models/models.ts
@@ -76,10 +76,10 @@ export class SettingsInput {
   vaultLockTimeoutSeconds: number
 
   @Field(() => Boolean)
-  autofillCredentialsEnabled: boolean
-
-  @Field(() => Boolean)
   autofillTOTPEnabled: boolean
+
+  @Field(() => String, { nullable: true })
+  autofillForbiddenUrlPatterns?: string
 
   @Field(() => String)
   uiLanguage: string
@@ -98,9 +98,6 @@ export class DefaultSettingsInput {
 
   @Field(() => Int, { nullable: false })
   vaultLockTimeoutSeconds: number
-
-  @Field(() => Boolean, { nullable: false })
-  autofillCredentialsEnabled: boolean
 
   @Field(() => Boolean, { nullable: false })
   autofillTOTPEnabled: boolean

--- a/backend/schemas/RootResolver.ts
+++ b/backend/schemas/RootResolver.ts
@@ -265,7 +265,6 @@ export class RootResolver {
           lastIpAddress: ipAddress,
           firebaseToken: firebaseToken,
           name: deviceName,
-          autofillCredentialsEnabled: true,
           vaultLockTimeoutSeconds: 28800,
           syncTOTP: true,
           autofillTOTPEnabled: true,

--- a/mobile-app/src/screens/Account/settings/DeviceSettings.tsx
+++ b/mobile-app/src/screens/Account/settings/DeviceSettings.tsx
@@ -39,8 +39,6 @@ export function DeviceSettings() {
   const currentSettings = (): SettingsInput => {
     return {
       autofillTOTPEnabled: deviceState.autofillTOTPEnabled as boolean,
-      autofillCredentialsEnabled:
-        deviceState.autofillCredentialsEnabled as boolean,
       uiLanguage: deviceState.uiLanguage as string,
       syncTOTP: deviceState.syncTOTP as boolean,
       vaultLockTimeoutSeconds: deviceState.vaultLockTimeoutSeconds as number,

--- a/mobile-app/src/screens/Account/settings/UserSettings.tsx
+++ b/mobile-app/src/screens/Account/settings/UserSettings.tsx
@@ -90,7 +90,6 @@ export function UserSettings() {
         vaultLockTimeoutSeconds: defaultData.vaultLockTimeoutSeconds,
         theme,
         syncTOTP: defaultData.syncTOTP,
-        autofillCredentialsEnabled: defaultData.autofillCredentialsEnabled,
         autofillTOTPEnabled: defaultData.autofillTOTPEnabled
       }
 
@@ -114,7 +113,6 @@ export function UserSettings() {
           theme: form.theme,
           vaultLockTimeoutSeconds: form.vaultLockTimeoutSeconds,
           autofillTOTPEnabled: form.autofillTOTPEnabled,
-          autofillCredentialsEnabled: form.autofillCredentialsEnabled,
           syncTOTP: form.syncTOTP,
           uiLanguage
         }
@@ -348,23 +346,6 @@ export function UserSettings() {
                       setForm({
                         ...(form as DefaultSettingsInput),
                         syncTOTP: e
-                      })
-                    }}
-                    size="md"
-                  />
-                </HStack>
-                <HStack
-                  justifyContent="space-between"
-                  alignContent="center"
-                  p={2}
-                >
-                  <Trans>Credentials autofill</Trans>
-                  <Switch
-                    value={form?.autofillCredentialsEnabled}
-                    onToggle={async (e) => {
-                      setForm({
-                        ...(form as DefaultSettingsInput),
-                        autofillCredentialsEnabled: e
                       })
                     }}
                     size="md"

--- a/mobile-app/src/screens/Auth/LoginAwaitingApproval.tsx
+++ b/mobile-app/src/screens/Auth/LoginAwaitingApproval.tsx
@@ -200,8 +200,7 @@ export const useLogin = (props: { deviceName: string }) => {
               addNewDeviceForUser.user.device.vaultLockTimeoutSeconds,
             autofillTOTPEnabled:
               addNewDeviceForUser.user.device.autofillTOTPEnabled,
-            autofillCredentialsEnabled:
-              addNewDeviceForUser.user.device.autofillCredentialsEnabled,
+            autofillCredentialsEnabled: true,
             uiLanguage: addNewDeviceForUser.user.uiLanguage,
             syncTOTP: addNewDeviceForUser.user.device.syncTOTP,
             lockTimeEnd:

--- a/mobile-app/src/screens/Auth/Register.tsx
+++ b/mobile-app/src/screens/Auth/Register.tsx
@@ -141,7 +141,7 @@ export function Register({ navigation }: NavigationProps) {
         syncTOTP: null,
         uiLanguage: null,
         autofillTOTPEnabled: null,
-        autofillCredentialsEnabled: null,
+        autofillCredentialsEnabled: true,
         lockTimeEnd: null,
         theme: 'dark',
         notificationOnWrongPasswordAttempts:

--- a/mobile-app/src/screens/DefaultDeviceSettingsModal.tsx
+++ b/mobile-app/src/screens/DefaultDeviceSettingsModal.tsx
@@ -52,7 +52,6 @@ export function DefaultDeviceSettingsModal() {
     uiLanguage: 'en',
     theme: 'dark',
     syncTOTP: true,
-    autofillCredentialsEnabled: true,
     autofillTOTPEnabled: true
   })
 
@@ -135,20 +134,6 @@ export function DefaultDeviceSettingsModal() {
                   alignContent="center"
                   p={2}
                 >
-                  <Text>Credentials autofill</Text>
-                  <Switch
-                    value={form.autofillCredentialsEnabled}
-                    onToggle={async (e) => {
-                      setForm({ ...form, autofillCredentialsEnabled: e })
-                    }}
-                    size="md"
-                  />
-                </HStack>
-                <HStack
-                  justifyContent="space-between"
-                  alignContent="center"
-                  p={2}
-                >
                   <Text>TOTP autofill</Text>
                   <Switch
                     value={form.autofillTOTPEnabled}
@@ -205,7 +190,6 @@ export function DefaultDeviceSettingsModal() {
               onPress={async () => {
                 const formData = {
                   uiLanguage: form.uiLanguage,
-                  autofillCredentialsEnabled: form.autofillCredentialsEnabled,
                   syncTOTP: form.syncTOTP,
                   autofillTOTPEnabled: form.autofillTOTPEnabled,
                   vaultLockTimeoutSeconds: form.vaultLockTimeoutSeconds

--- a/mobile-app/src/utils/deviceStore.ts
+++ b/mobile-app/src/utils/deviceStore.ts
@@ -249,8 +249,6 @@ export const useDeviceStore = create<Device>()(
 
           const config = {
             autofillTOTPEnabled: queryData.currentDevice.autofillTOTPEnabled,
-            autofillCredentialsEnabled:
-              queryData.currentDevice.autofillCredentialsEnabled,
             syncTOTP: queryData.currentDevice.syncTOTP,
             vaultLockTimeoutSeconds:
               queryData.currentDevice.vaultLockTimeoutSeconds,

--- a/shared/autofillForbiddenUrlPatterns.ts
+++ b/shared/autofillForbiddenUrlPatterns.ts
@@ -1,0 +1,45 @@
+import { constructURL } from './urlUtils'
+
+export const parseAutofillForbiddenUrlPatterns = (value: string): string[] => {
+  const patterns = value
+    .split(/\r?\n/)
+    .map((pattern) => pattern.trim())
+    .filter(Boolean)
+
+  return [...new Set(patterns)]
+}
+
+export const serializeAutofillForbiddenUrlPatterns = (value: string): string =>
+  parseAutofillForbiddenUrlPatterns(value).join('\n')
+
+const urlPatternToRegExp = (pattern: string): RegExp => {
+  const escapedPattern = pattern
+    .replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+    .replace(/\*/g, '.*')
+
+  return new RegExp(`^${escapedPattern}$`)
+}
+
+export const isAutofillForbiddenForUrl = (
+  url: string,
+  forbiddenUrlPatterns: string
+): boolean => {
+  const parsedUrl = constructURL(url)
+
+  if (!parsedUrl.href) {
+    return false
+  }
+
+  const normalizedUrl = new URL(parsedUrl.href)
+  const urlWithoutProtocol = `${normalizedUrl.host}${normalizedUrl.pathname}${normalizedUrl.search}${normalizedUrl.hash}`
+
+  return parseAutofillForbiddenUrlPatterns(forbiddenUrlPatterns).some(
+    (pattern) => {
+      const candidateUrl = pattern.includes('://')
+        ? normalizedUrl.href
+        : urlWithoutProtocol
+
+      return urlPatternToRegExp(pattern).test(candidateUrl)
+    }
+  )
+}

--- a/shared/generated/graphqlBaseTypes.ts
+++ b/shared/generated/graphqlBaseTypes.ts
@@ -148,7 +148,6 @@ export type DecryptionChallengeMutation = {
 
 export type DefaultDeviceSettingsGql = {
   __typename?: 'DefaultDeviceSettingsGQL'
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   id: Scalars['Int']['output']
@@ -162,7 +161,6 @@ export type DefaultDeviceSettingsGql = {
 
 export type DefaultDeviceSettingsGqlScalars = {
   __typename?: 'DefaultDeviceSettingsGQLScalars'
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   id: Scalars['Int']['output']
@@ -175,7 +173,6 @@ export type DefaultDeviceSettingsGqlScalars = {
 
 export type DefaultDeviceSettingsMutation = {
   __typename?: 'DefaultDeviceSettingsMutation'
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   id: Scalars['Int']['output']
@@ -193,7 +190,6 @@ export type DefaultDeviceSettingsMutationUpdateArgs = {
 
 export type DefaultDeviceSettingsQuery = {
   __typename?: 'DefaultDeviceSettingsQuery'
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   /** 0 index for system defaults */
@@ -206,7 +202,6 @@ export type DefaultDeviceSettingsQuery = {
 }
 
 export type DefaultSettingsInput = {
-  autofillCredentialsEnabled: Scalars['Boolean']['input']
   autofillTOTPEnabled: Scalars['Boolean']['input']
   syncTOTP: Scalars['Boolean']['input']
   theme: Scalars['String']['input']
@@ -220,7 +215,6 @@ export type DeviceGql = {
   SecretUsageEvents: Array<SecretUsageEventGql>
   User: UserGql
   UserMaster?: Maybe<UserGql>
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   deletedAt?: Maybe<Scalars['DateTime']['output']>
@@ -257,7 +251,6 @@ export type DeviceLocation = {
 
 export type DeviceMutation = {
   __typename?: 'DeviceMutation'
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   deletedAt?: Maybe<Scalars['DateTime']['output']>
@@ -308,7 +301,6 @@ export type DeviceQuery = {
   SecretUsageEvents: Array<SecretUsageEventGql>
   User: UserGql
   UserMaster?: Maybe<UserGql>
-  autofillCredentialsEnabled: Scalars['Boolean']['output']
   autofillTOTPEnabled: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
   deletedAt?: Maybe<Scalars['DateTime']['output']>
@@ -552,7 +544,7 @@ export type SecretUsageEventInput = {
 }
 
 export type SettingsInput = {
-  autofillCredentialsEnabled: Scalars['Boolean']['input']
+  autofillForbiddenUrlPatterns?: InputMaybe<Scalars['String']['input']>
   autofillTOTPEnabled: Scalars['Boolean']['input']
   notificationOnVaultUnlock: Scalars['Boolean']['input']
   notificationOnWrongPasswordAttempts: Scalars['Int']['input']
@@ -602,6 +594,7 @@ export type UserGql = {
   UserPaidProducts: Array<UserPaidProductsGql>
   WebInputsAdded: Array<WebInputGql>
   addDeviceSecretEncrypted: Scalars['String']['output']
+  autofillForbiddenUrlPatterns: Scalars['String']['output']
   createdAt: Scalars['DateTime']['output']
   deviceRecoveryCooldownMinutes: Scalars['Int']['output']
   email?: Maybe<Scalars['String']['output']>
@@ -636,6 +629,7 @@ export type UserMutation = {
   addDevice: DeviceGql
   addDeviceSecretEncrypted: Scalars['String']['output']
   addEncryptedSecrets: Array<EncryptedSecretQuery>
+  autofillForbiddenUrlPatterns: Scalars['String']['output']
   changeEmail: UserQuery
   changeMasterPassword: Scalars['Int']['output']
   createCheckoutSession: Scalars['String']['output']
@@ -768,6 +762,7 @@ export type UserQuery = {
   UserPaidProducts: Array<UserPaidProductsGql>
   WebInputsAdded: Array<WebInputGql>
   addDeviceSecretEncrypted: Scalars['String']['output']
+  autofillForbiddenUrlPatterns: Scalars['String']['output']
   createdAt: Scalars['DateTime']['output']
   decryptionChallengesWaiting: Array<DecryptionChallengeForApproval>
   defaultDeviceSettings: DefaultDeviceSettingsQuery

--- a/shared/graphql/DefaultSettings.codegen.tsx
+++ b/shared/graphql/DefaultSettings.codegen.tsx
@@ -9,7 +9,7 @@ export type UpdateDefaultDeviceSettingsMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateDefaultDeviceSettingsMutation = { __typename?: 'Mutation', me: { __typename?: 'UserMutation', defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsMutation', id: number, update: { __typename?: 'DefaultDeviceSettingsGQLScalars', id: number, autofillTOTPEnabled: boolean, autofillCredentialsEnabled: boolean, theme: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number } } } };
+export type UpdateDefaultDeviceSettingsMutation = { __typename?: 'Mutation', me: { __typename?: 'UserMutation', defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsMutation', id: number, update: { __typename?: 'DefaultDeviceSettingsGQLScalars', id: number, autofillTOTPEnabled: boolean, theme: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number } } } };
 
 export type UpdateMasterDeviceResetTimeoutMutationVariables = Types.Exact<{
   deviceRecoveryCooldownMinutes: Types.Scalars['NonNegativeInt']['input'];
@@ -21,7 +21,7 @@ export type UpdateMasterDeviceResetTimeoutMutation = { __typename?: 'Mutation', 
 export type DefaultSettingsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DefaultSettingsQuery = { __typename?: 'Query', me: { __typename?: 'UserQuery', id: string, masterDeviceId?: string | null, uiLanguage: string, deviceRecoveryCooldownMinutes: number, defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsQuery', id: number, autofillTOTPEnabled: boolean, autofillCredentialsEnabled: boolean, syncTOTP: boolean, vaultLockTimeoutSeconds: number, theme: string } } };
+export type DefaultSettingsQuery = { __typename?: 'Query', me: { __typename?: 'UserQuery', id: string, masterDeviceId?: string | null, uiLanguage: string, deviceRecoveryCooldownMinutes: number, defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsQuery', id: number, autofillTOTPEnabled: boolean, syncTOTP: boolean, vaultLockTimeoutSeconds: number, theme: string } } };
 
 
 export const UpdateDefaultDeviceSettingsDocument = gql`
@@ -32,7 +32,6 @@ export const UpdateDefaultDeviceSettingsDocument = gql`
       update(config: $config) {
         id
         autofillTOTPEnabled
-        autofillCredentialsEnabled
         theme
         syncTOTP
         vaultLockTimeoutSeconds
@@ -111,7 +110,6 @@ export const DefaultSettingsDocument = gql`
     defaultDeviceSettings {
       id
       autofillTOTPEnabled
-      autofillCredentialsEnabled
       syncTOTP
       vaultLockTimeoutSeconds
       theme

--- a/shared/graphql/DefaultSettings.gql
+++ b/shared/graphql/DefaultSettings.gql
@@ -5,7 +5,6 @@ mutation updateDefaultDeviceSettings($config: DefaultSettingsInput!) {
       update(config: $config) {
         id
         autofillTOTPEnabled
-        autofillCredentialsEnabled
         theme
         syncTOTP
         vaultLockTimeoutSeconds
@@ -36,7 +35,6 @@ query defaultSettings {
     defaultDeviceSettings {
       id
       autofillTOTPEnabled
-      autofillCredentialsEnabled
       syncTOTP
       vaultLockTimeoutSeconds
       theme

--- a/shared/graphql/Login.codegen.tsx
+++ b/shared/graphql/Login.codegen.tsx
@@ -14,7 +14,7 @@ export type AddNewDeviceForUserMutationVariables = Types.Exact<{
 
 
 export type AddNewDeviceForUserMutation = { __typename?: 'Mutation', deviceDecryptionChallenge?:
-    | { __typename?: 'DecryptionChallengeApproved', id: number, addNewDeviceForUser: { __typename?: 'LoginResponse', accessToken: string, user: { __typename?: 'UserMutation', id: string, uiLanguage: string, notificationOnVaultUnlock: boolean, notificationOnWrongPasswordAttempts: number, EncryptedSecrets: Array<{ __typename?: 'EncryptedSecretGQL', id: string, encrypted: string, kind: Types.EncryptedSecretType, createdAt: string, updatedAt?: string | null, version: number }>, device: { __typename?: 'DeviceMutation', id: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number, autofillCredentialsEnabled: boolean, autofillTOTPEnabled: boolean }, defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsMutation', id: number, autofillTOTPEnabled: boolean, autofillCredentialsEnabled: boolean, theme: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number } } } }
+    | { __typename?: 'DecryptionChallengeApproved', id: number, addNewDeviceForUser: { __typename?: 'LoginResponse', accessToken: string, user: { __typename?: 'UserMutation', id: string, uiLanguage: string, notificationOnVaultUnlock: boolean, notificationOnWrongPasswordAttempts: number, autofillForbiddenUrlPatterns: string, EncryptedSecrets: Array<{ __typename?: 'EncryptedSecretGQL', id: string, encrypted: string, kind: Types.EncryptedSecretType, createdAt: string, updatedAt?: string | null, version: number }>, device: { __typename?: 'DeviceMutation', id: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number, autofillTOTPEnabled: boolean }, defaultDeviceSettings: { __typename?: 'DefaultDeviceSettingsMutation', id: number, autofillTOTPEnabled: boolean, theme: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number } } } }
     | { __typename?: 'DecryptionChallengeForApproval' }
    | null };
 
@@ -62,17 +62,16 @@ export const AddNewDeviceForUserDocument = gql`
           }
           notificationOnVaultUnlock
           notificationOnWrongPasswordAttempts
+          autofillForbiddenUrlPatterns
           device(id: $deviceId) {
             id
             syncTOTP
             vaultLockTimeoutSeconds
-            autofillCredentialsEnabled
             autofillTOTPEnabled
           }
           defaultDeviceSettings {
             id
             autofillTOTPEnabled
-            autofillCredentialsEnabled
             theme
             syncTOTP
             vaultLockTimeoutSeconds

--- a/shared/graphql/Login.gql
+++ b/shared/graphql/Login.gql
@@ -26,17 +26,16 @@ mutation addNewDeviceForUser(
           }
           notificationOnVaultUnlock
           notificationOnWrongPasswordAttempts
+          autofillForbiddenUrlPatterns
           device(id: $deviceId) {
             id
             syncTOTP
             vaultLockTimeoutSeconds
-            autofillCredentialsEnabled
             autofillTOTPEnabled
           }
           defaultDeviceSettings {
             id
             autofillTOTPEnabled
-            autofillCredentialsEnabled
             theme
             syncTOTP
             vaultLockTimeoutSeconds

--- a/shared/graphql/Settings.codegen.tsx
+++ b/shared/graphql/Settings.codegen.tsx
@@ -7,7 +7,7 @@ const defaultOptions = {} as const;
 export type SyncSettingsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type SyncSettingsQuery = { __typename?: 'Query', me: { __typename?: 'UserQuery', id: string, loginCredentialsLimit: number, TOTPlimit: number, notificationOnVaultUnlock: boolean, notificationOnWrongPasswordAttempts: number, uiLanguage: string }, currentDevice: { __typename?: 'DeviceQuery', id: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number, autofillCredentialsEnabled: boolean, autofillTOTPEnabled: boolean } };
+export type SyncSettingsQuery = { __typename?: 'Query', me: { __typename?: 'UserQuery', id: string, loginCredentialsLimit: number, TOTPlimit: number, notificationOnVaultUnlock: boolean, notificationOnWrongPasswordAttempts: number, uiLanguage: string, autofillForbiddenUrlPatterns: string }, currentDevice: { __typename?: 'DeviceQuery', id: string, syncTOTP: boolean, vaultLockTimeoutSeconds: number, autofillTOTPEnabled: boolean } };
 
 export type UpdateSettingsMutationVariables = Types.Exact<{
   config: Types.SettingsInput;
@@ -26,12 +26,12 @@ export const SyncSettingsDocument = gql`
     notificationOnVaultUnlock
     notificationOnWrongPasswordAttempts
     uiLanguage
+    autofillForbiddenUrlPatterns
   }
   currentDevice {
     id
     syncTOTP
     vaultLockTimeoutSeconds
-    autofillCredentialsEnabled
     autofillTOTPEnabled
   }
 }

--- a/shared/graphql/Settings.gql
+++ b/shared/graphql/Settings.gql
@@ -6,12 +6,12 @@ query SyncSettings {
     notificationOnVaultUnlock
     notificationOnWrongPasswordAttempts
     uiLanguage
+    autofillForbiddenUrlPatterns
   }
   currentDevice {
     id
     syncTOTP
     vaultLockTimeoutSeconds
-    autofillCredentialsEnabled
     autofillTOTPEnabled
   }
 }

--- a/web-extension/authier.graphql
+++ b/web-extension/authier.graphql
@@ -31,6 +31,7 @@ type UserQuery {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
   recoveryDecryptionChallenge: DecryptionChallengeGQL
@@ -99,6 +100,7 @@ type UserGQL {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
   recoveryDecryptionChallenge: DecryptionChallengeGQL
@@ -124,7 +126,6 @@ type DeviceGQL {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -255,7 +256,6 @@ type DefaultDeviceSettingsGQL {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -275,7 +275,6 @@ type DeviceQuery {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -319,7 +318,6 @@ type DefaultDeviceSettingsQuery {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -419,6 +417,7 @@ type UserMutation {
   deviceRecoveryCooldownMinutes: Int!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!
+  autofillForbiddenUrlPatterns: String!
   Token: [TokenGQL!]!
   masterDevice: DeviceGQL
   recoveryDecryptionChallenge: DecryptionChallengeGQL
@@ -473,7 +472,6 @@ type DeviceMutation {
   logoutAt: DateTime
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime
@@ -531,7 +529,6 @@ type DefaultDeviceSettingsMutation {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -544,7 +541,6 @@ type DefaultDeviceSettingsGQLScalars {
   id: Int!
   createdAt: DateTime!
   updatedAt: DateTime
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   theme: String!
   syncTOTP: Boolean!
@@ -555,7 +551,6 @@ type DefaultDeviceSettingsGQLScalars {
 input DefaultSettingsInput {
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
   uiLanguage: String!
   theme: String!
@@ -597,8 +592,8 @@ input SecretUsageEventInput {
 input SettingsInput {
   syncTOTP: Boolean!
   vaultLockTimeoutSeconds: Int!
-  autofillCredentialsEnabled: Boolean!
   autofillTOTPEnabled: Boolean!
+  autofillForbiddenUrlPatterns: String
   uiLanguage: String!
   notificationOnVaultUnlock: Boolean!
   notificationOnWrongPasswordAttempts: Int!

--- a/web-extension/src/background/ExtensionDevice.ts
+++ b/web-extension/src/background/ExtensionDevice.ts
@@ -9,9 +9,9 @@ import {
 } from './backgroundPage'
 import {
   EncryptedSecretPatchInput,
-  EncryptedSecretType,
-  SettingsInput
+  EncryptedSecretType
 } from '../../../shared/generated/graphqlBaseTypes'
+import type { SecuritySettings } from './backgroundSchemas'
 import { apolloClient } from '@src/apollo/apolloClient'
 import {
   SyncEncryptedSecretsDocument,
@@ -56,6 +56,10 @@ import {
   WebInputsForHostsQueryVariables
 } from './chromeRuntimeListener.codegen'
 import { WebInputForAutofill } from './WebInputForAutofill'
+import {
+  getAutofillCredentialsEnabled,
+  setAutofillCredentialsEnabled
+} from '@src/util/autofillCredentialsPreference'
 
 export const log = debug('au:Device')
 
@@ -105,6 +109,10 @@ export class DeviceState implements IBackgroundStateSerializable {
   webInputs: WebInputForAutofill[]
   constructor(parameters: IBackgroundStateSerializable) {
     Object.assign(this, parameters)
+    this.autofillCredentialsEnabled =
+      parameters.autofillCredentialsEnabled ?? true
+    this.autofillForbiddenUrlPatterns =
+      parameters.autofillForbiddenUrlPatterns ?? ''
     //log('device state created', this)
 
     browser.storage.onChanged.addListener(this.onStorageChange)
@@ -122,6 +130,7 @@ export class DeviceState implements IBackgroundStateSerializable {
   syncTOTP: boolean
   autofillCredentialsEnabled: boolean
   autofillTOTPEnabled: boolean
+  autofillForbiddenUrlPatterns: string
   uiLanguage: string
   theme: string
   authSecret: string
@@ -197,10 +206,13 @@ export class DeviceState implements IBackgroundStateSerializable {
     device.lockedState = null
     //TODO: Fix perf
     this.decryptedSecrets = await this.getAllSecretsDecrypted()
-    await browser.storage.local.set({
-      backgroundState: this,
-      lockedState: null
-    })
+    await Promise.all([
+      browser.storage.local.set({
+        backgroundState: this,
+        lockedState: null
+      }),
+      setAutofillCredentialsEnabled(this.autofillCredentialsEnabled)
+    ])
     if (isRunningInBgServiceWorker) {
       const icon = browser.runtime.getURL('icon-48.png')
       browser.action.setIcon({ path: icon })
@@ -560,12 +572,18 @@ class ExtensionDevice {
     return `${browserInfo.getOSName()} ${browserInfo.getBrowserName()} extension`
   }
   async clearLocalStorage() {
-    const deviceId = await this.getDeviceId()
+    const [deviceId, autofillCredentialsEnabled] = await Promise.all([
+      this.getDeviceId(),
+      getAutofillCredentialsEnabled()
+    ])
     this.state?.destroy()
     await browser.storage.local.clear()
     this.state = null
 
-    await browser.storage.local.set({ deviceId: deviceId }) // restore deviceId so that we keep it even after logout
+    await Promise.all([
+      browser.storage.local.set({ deviceId }),
+      setAutofillCredentialsEnabled(autofillCredentialsEnabled)
+    ])
   }
   /**
    * @returns a stored deviceId or a new UUID if the extension was just installed
@@ -646,6 +664,7 @@ class ExtensionDevice {
       syncTOTP,
       autofillCredentialsEnabled,
       autofillTOTPEnabled,
+      autofillForbiddenUrlPatterns,
       uiLanguage,
       theme,
       authSecret,
@@ -668,6 +687,7 @@ class ExtensionDevice {
       syncTOTP,
       autofillTOTPEnabled,
       autofillCredentialsEnabled,
+      autofillForbiddenUrlPatterns,
       uiLanguage,
       theme
     }
@@ -732,7 +752,7 @@ class ExtensionDevice {
     )
   }
 
-  setDeviceSettings(config: SettingsInput) {
+  async setDeviceSettings(config: SecuritySettings) {
     if (!this.state) {
       console.warn('cannot set device settings, device not initialized')
       return
@@ -740,6 +760,9 @@ class ExtensionDevice {
 
     this.state.autofillCredentialsEnabled = config.autofillCredentialsEnabled
     this.state.autofillTOTPEnabled = config.autofillTOTPEnabled
+    this.state.autofillForbiddenUrlPatterns =
+      config.autofillForbiddenUrlPatterns ??
+      this.state.autofillForbiddenUrlPatterns
     this.state.syncTOTP = config.syncTOTP
     this.state.uiLanguage = config.uiLanguage
     this.state.notificationOnWrongPasswordAttempts =
@@ -748,7 +771,7 @@ class ExtensionDevice {
 
     device.setLockTime(config.vaultLockTimeoutSeconds)
 
-    this.state.save()
+    await this.state.save()
   }
 
   async save(deviceState: IBackgroundStateSerializable) {

--- a/web-extension/src/background/backgroundPage.ts
+++ b/web-extension/src/background/backgroundPage.ts
@@ -34,6 +34,7 @@ export interface IBackgroundStateSerializableLocked {
   syncTOTP: boolean | null
   autofillCredentialsEnabled: boolean | null
   autofillTOTPEnabled: boolean | null
+  autofillForbiddenUrlPatterns: string
   uiLanguage: string | null
   theme: string
   notificationOnVaultUnlock: boolean

--- a/web-extension/src/background/backgroundSchemas.ts
+++ b/web-extension/src/background/backgroundSchemas.ts
@@ -53,12 +53,15 @@ export const webInputElementSchema = z.object({
 export const settingsSchema = z.object({
   autofillCredentialsEnabled: z.boolean(),
   autofillTOTPEnabled: z.boolean(),
+  autofillForbiddenUrlPatterns: z.string().optional(),
   uiLanguage: z.string(),
   syncTOTP: z.boolean(),
   vaultLockTimeoutSeconds: z.number(),
   notificationOnVaultUnlock: z.boolean(),
   notificationOnWrongPasswordAttempts: z.number()
 })
+
+export type SecuritySettings = z.infer<typeof settingsSchema>
 
 export const backgroundStateSerializableLockedSchema = z.object({
   email: z.string(),
@@ -80,6 +83,7 @@ export const backgroundStateSerializableLockedSchema = z.object({
   vaultLockTimeoutSeconds: z.number().nullable(),
   autofillCredentialsEnabled: z.boolean().nullable(),
   autofillTOTPEnabled: z.boolean().nullable(),
+  autofillForbiddenUrlPatterns: z.string().default(''),
   uiLanguage: z.string().nullable(),
   syncTOTP: z.boolean().nullable(),
   theme: z.string(),

--- a/web-extension/src/background/chromeRuntimeListener.ts
+++ b/web-extension/src/background/chromeRuntimeListener.ts
@@ -271,7 +271,7 @@ const appRouter = tc.router({
       const deviceState = device.state
       // console.log('securitySettings', input, device.state)
       if (deviceState) {
-        device.setDeviceSettings(input)
+        await device.setDeviceSettings(input)
       }
 
       return true

--- a/web-extension/src/background/getContentScriptInitialState.ts
+++ b/web-extension/src/background/getContentScriptInitialState.ts
@@ -6,6 +6,7 @@ import { ILoginSecret, ITOTPSecret } from '@src/util/useDeviceState'
 
 import debug from 'debug'
 import { constructURL } from '@shared/urlUtils'
+import { isAutofillForbiddenForUrl } from '@shared/autofillForbiddenUrlPatterns'
 import { getWebInputsForUrl } from './getWebInputsForUrl'
 const log = debug('au:getContentScriptInitialState')
 
@@ -113,7 +114,12 @@ export const getContentScriptInitialState = async (
   return {
     extensionDeviceReady: !!device.state?.masterEncryptionKey,
     //TODO: Add autofill for TOTP
-    autofillEnabled: !!device.state?.autofillCredentialsEnabled,
+    autofillEnabled:
+      !!device.state?.autofillCredentialsEnabled &&
+      !isAutofillForbiddenForUrl(
+        tabUrl,
+        device.state?.autofillForbiddenUrlPatterns ?? ''
+      ),
     webInputs: webInputs,
     passwordCount:
       device.state?.secrets.filter(

--- a/web-extension/src/components/vault/settings/DeviceDefaultsForm.tsx
+++ b/web-extension/src/components/vault/settings/DeviceDefaultsForm.tsx
@@ -20,7 +20,6 @@ import { useVaultLockTimeoutOptions } from '@src/util/useVaultLockTimeoutOptions
 interface Values {
   vaultLockTimeoutSeconds: number
   deviceRecoveryCooldownMinutes: number
-  autofillCredentialsEnabled: boolean
   autofillTOTPEnabled: boolean
   syncTOTP: boolean
   uiLanguage: string
@@ -99,8 +98,6 @@ export function DeviceDefaultsForm() {
           initialValues={{
             autofillTOTPEnabled:
               data.me.defaultDeviceSettings.autofillTOTPEnabled,
-            autofillCredentialsEnabled:
-              data.me.defaultDeviceSettings.autofillCredentialsEnabled,
             syncTOTP: data.me.defaultDeviceSettings.syncTOTP,
             vaultLockTimeoutSeconds:
               data.me.defaultDeviceSettings.vaultLockTimeoutSeconds,
@@ -115,7 +112,6 @@ export function DeviceDefaultsForm() {
           ) => {
             const config = {
               autofillTOTPEnabled: values.autofillTOTPEnabled,
-              autofillCredentialsEnabled: values.autofillCredentialsEnabled,
               syncTOTP: values.syncTOTP,
               theme: values.theme,
               uiLanguage: values.uiLanguage,
@@ -250,14 +246,6 @@ export function DeviceDefaultsForm() {
               </div>
 
               <div className="grid gap-4">
-                <SettingToggle
-                  checked={values.autofillCredentialsEnabled}
-                  description="Offer saved credentials for autofill on new devices."
-                  label="Credentials autofill"
-                  onCheckedChange={(checked) => {
-                    setFieldValue('autofillCredentialsEnabled', checked)
-                  }}
-                />
                 <SettingToggle
                   checked={values.autofillTOTPEnabled}
                   description="Enable one-time password autofill by default."

--- a/web-extension/src/components/vault/settings/Security.tsx
+++ b/web-extension/src/components/vault/settings/Security.tsx
@@ -16,12 +16,15 @@ import {
 } from '@src/components/ui/card'
 import { Switch } from '@src/components/ui/switch'
 import { useVaultLockTimeoutOptions } from '@src/util/useVaultLockTimeoutOptions'
+import { serializeAutofillForbiddenUrlPatterns } from '@shared/autofillForbiddenUrlPatterns'
+import { toBackendSettings } from '@src/util/securitySettings'
 
 interface Values {
   vaultLockTimeoutSeconds: number
   uiLanguage: string
   autofillCredentialsEnabled: boolean
   autofillTOTPEnabled: boolean
+  autofillForbiddenUrlPatterns: string
   syncTOTP: boolean
   notificationOnWrongPasswordAttempts: number
   notificationOnVaultUnlock: boolean
@@ -44,8 +47,7 @@ export default function Security() {
       <CardHeader>
         <CardTitle>Security behavior</CardTitle>
         <CardDescription>
-          Control locking, language, autofill, and vault notifications for this
-          device.
+          Control locking, language, autofill, and vault notifications.
         </CardDescription>
       </CardHeader>
 
@@ -54,6 +56,8 @@ export default function Security() {
           initialValues={{
             autofillTOTPEnabled: deviceState.autofillTOTPEnabled,
             autofillCredentialsEnabled: deviceState.autofillCredentialsEnabled,
+            autofillForbiddenUrlPatterns:
+              deviceState.autofillForbiddenUrlPatterns,
             uiLanguage: deviceState.uiLanguage,
             syncTOTP: deviceState.syncTOTP,
             vaultLockTimeoutSeconds: deviceState.vaultLockTimeoutSeconds,
@@ -67,18 +71,22 @@ export default function Security() {
           ) => {
             const config = {
               ...values,
+              autofillForbiddenUrlPatterns:
+                serializeAutofillForbiddenUrlPatterns(
+                  values.autofillForbiddenUrlPatterns
+                ),
               vaultLockTimeoutSeconds: Number.parseInt(
                 values.vaultLockTimeoutSeconds.toString(),
                 10
               )
             }
 
+            await setSecuritySettings(config)
             await updateSettings({
               variables: {
-                config
+                config: toBackendSettings(config)
               }
             })
-            setSecuritySettings(config)
             resetForm({ values: config })
             setSubmitting(false)
           }}
@@ -140,7 +148,7 @@ export default function Security() {
               <div className="grid gap-4">
                 <SettingToggle
                   checked={values.autofillCredentialsEnabled}
-                  description="Allow saved credentials to be offered for autofill."
+                  description="Enable login autofill in this browser. This preference is stored only on this device."
                   label="Credentials autofill"
                   onCheckedChange={(checked) => {
                     setFieldValue('autofillCredentialsEnabled', checked)
@@ -154,6 +162,35 @@ export default function Security() {
                     setFieldValue('autofillTOTPEnabled', checked)
                   }}
                 />
+              </div>
+
+              <Field name="autofillForbiddenUrlPatterns">
+                {() => (
+                  <FormField
+                    description="These patterns disable autofill on every device. Enter one URL pattern per line and use * as a wildcard."
+                    label="Never autofill on"
+                  >
+                    <textarea
+                      className="min-h-32 w-full resize-y rounded-[var(--radius-md)] border border-[color:var(--color-border)] bg-[color:var(--color-input)] px-3 py-2 text-sm text-[color:var(--color-foreground)] outline-none transition placeholder:text-[color:var(--color-muted)] focus:border-[color:var(--color-ring)] focus:ring-2 focus:ring-[color:var(--color-ring)]/30"
+                      id="autofillForbiddenUrlPatterns"
+                      name="autofillForbiddenUrlPatterns"
+                      onChange={(event) => {
+                        setFieldValue(
+                          'autofillForbiddenUrlPatterns',
+                          event.target.value
+                        )
+                      }}
+                      placeholder={
+                        'www.google.com/my-path/*\nhttps://internal.company.test/*'
+                      }
+                      spellCheck={false}
+                      value={values.autofillForbiddenUrlPatterns}
+                    />
+                  </FormField>
+                )}
+              </Field>
+
+              <div className="grid gap-4">
                 <SettingToggle
                   checked={values.syncTOTP}
                   description="Keep your one-time password data synced to this device."

--- a/web-extension/src/pages-vault/LoginAwaitingApproval.tsx
+++ b/web-extension/src/pages-vault/LoginAwaitingApproval.tsx
@@ -18,6 +18,7 @@ import {
 } from '@shared/graphql/Login.codegen'
 import { getUserFromToken, setAccessToken } from '../util/accessTokenExtension'
 import { IBackgroundStateSerializable } from '@src/background/backgroundPage'
+import { getAutofillCredentialsEnabled } from '@src/util/autofillCredentialsPreference'
 import {
   base64ToBuffer,
   cryptoKeyToString,
@@ -201,8 +202,9 @@ export const useLogin = (props: { deviceName: string }) => {
             addNewDeviceForUser.user.device.vaultLockTimeoutSeconds,
           autofillTOTPEnabled:
             addNewDeviceForUser.user.device.autofillTOTPEnabled,
-          autofillCredentialsEnabled:
-            addNewDeviceForUser.user.device.autofillCredentialsEnabled,
+          autofillCredentialsEnabled: await getAutofillCredentialsEnabled(),
+          autofillForbiddenUrlPatterns:
+            addNewDeviceForUser.user.autofillForbiddenUrlPatterns,
           uiLanguage: addNewDeviceForUser.user.uiLanguage,
           syncTOTP: addNewDeviceForUser.user.device.syncTOTP,
           notificationOnWrongPasswordAttempts:

--- a/web-extension/src/pages-vault/Register.tsx
+++ b/web-extension/src/pages-vault/Register.tsx
@@ -9,6 +9,7 @@ import { setAccessToken } from '@src/util/accessTokenExtension'
 import { device } from '@src/background/ExtensionDevice'
 import { Trans } from '@lingui/react/macro'
 import type { IBackgroundStateSerializable } from '@src/background/backgroundPage'
+import { getAutofillCredentialsEnabled } from '@src/util/autofillCredentialsPreference'
 import {
   bufferToBase64,
   cryptoKeyToString,
@@ -150,7 +151,8 @@ export default function Register() {
             authSecretEncrypted: params.addDeviceSecretEncrypted,
             vaultLockTimeoutSeconds: null,
             autofillTOTPEnabled: null,
-            autofillCredentialsEnabled: null,
+            autofillCredentialsEnabled: await getAutofillCredentialsEnabled(),
+            autofillForbiddenUrlPatterns: '',
             uiLanguage: null,
             syncTOTP: null,
             theme: 'dark',

--- a/web-extension/src/pages-vault/VaultList.tsx
+++ b/web-extension/src/pages-vault/VaultList.tsx
@@ -17,8 +17,11 @@ import { Input } from '@src/components/ui/input'
 import { Tooltip } from '@src/components/ui/tooltip'
 
 export const VaultList = ({ tableView }: { tableView: boolean }) => {
-  const { loginCredentials, TOTPSecrets, setSecuritySettings } =
+  const { deviceState, loginCredentials, TOTPSecrets, setSecuritySettings } =
     useContext(DeviceStateContext)
+  const autofillCredentialsEnabled =
+    deviceState?.autofillCredentialsEnabled ?? true
+  const isDeviceStateReady = deviceState !== null
   const navigate = useNavigate()
   const { data, loading, error } = useSyncSettingsQuery()
   const [filterBy, setFilterBy] = useQueryParam(
@@ -27,13 +30,14 @@ export const VaultList = ({ tableView }: { tableView: boolean }) => {
   )
 
   useEffect(() => {
-    if (!data) {
+    if (!data || !isDeviceStateReady) {
       return
     }
 
     setSecuritySettings({
-      autofillCredentialsEnabled: data.currentDevice.autofillCredentialsEnabled,
+      autofillCredentialsEnabled,
       autofillTOTPEnabled: data.currentDevice.autofillTOTPEnabled,
+      autofillForbiddenUrlPatterns: data.me.autofillForbiddenUrlPatterns,
       uiLanguage: data.me.uiLanguage,
       syncTOTP: data.currentDevice.syncTOTP,
       vaultLockTimeoutSeconds: data.currentDevice.vaultLockTimeoutSeconds,
@@ -41,7 +45,12 @@ export const VaultList = ({ tableView }: { tableView: boolean }) => {
         data.me.notificationOnWrongPasswordAttempts,
       notificationOnVaultUnlock: data.me.notificationOnVaultUnlock
     })
-  }, [data, setSecuritySettings])
+  }, [
+    autofillCredentialsEnabled,
+    data,
+    isDeviceStateReady,
+    setSecuritySettings
+  ])
 
   if (loading && !data) {
     return (

--- a/web-extension/src/pages/Home.tsx
+++ b/web-extension/src/pages/Home.tsx
@@ -39,11 +39,37 @@ export const Home = () => {
 
   return (
     <div className="px-2 pb-2">
-      <div className="sticky top-0 z-10 mt-2 flex items-center gap-3 px-2">
-        <label className="flex shrink-0 items-center gap-2 text-sm font-medium text-[color:var(--color-foreground)]">
+      <div className="sticky top-0 z-10 mt-2 flex items-center gap-2 px-2">
+        {deviceState ? (
+          <label className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-[color:var(--color-foreground)]">
+            <span>Autofill</span>
+            <Switch
+              checked={deviceState.autofillCredentialsEnabled}
+              onCheckedChange={(checked) => {
+                const config = {
+                  autofillCredentialsEnabled: checked,
+                  autofillTOTPEnabled: deviceState.autofillTOTPEnabled,
+                  autofillForbiddenUrlPatterns:
+                    deviceState.autofillForbiddenUrlPatterns,
+                  notificationOnVaultUnlock:
+                    deviceState.notificationOnVaultUnlock,
+                  notificationOnWrongPasswordAttempts:
+                    deviceState.notificationOnWrongPasswordAttempts,
+                  syncTOTP: deviceState.syncTOTP,
+                  uiLanguage: deviceState.uiLanguage,
+                  vaultLockTimeoutSeconds: deviceState.vaultLockTimeoutSeconds
+                }
+
+                void setSecuritySettings(config)
+              }}
+            />
+          </label>
+        ) : null}
+
+        <label className="flex shrink-0 items-center gap-1.5 text-sm font-medium text-[color:var(--color-foreground)]">
           <span className="inline-flex items-center gap-1.5 text-[color:var(--color-muted)]">
             <TbWorld className="size-4" />
-            TLD
+            Site
           </span>
           <Switch
             checked={filterByTLD}
@@ -54,7 +80,7 @@ export const Home = () => {
         </label>
 
         <Input
-          className="h-9"
+          className="h-9 min-w-0"
           placeholder="Search"
           value={search}
           onChange={(e) => {
@@ -74,35 +100,6 @@ export const Home = () => {
           />
         ) : null}
       </div>
-
-      {deviceState ? (
-        <div className="mt-3 px-2">
-          <label className="flex items-center justify-between rounded-[var(--radius-md)] border border-[color:var(--color-border)] bg-[color:var(--color-card)] px-3 py-2 text-sm text-[color:var(--color-foreground)]">
-            <div className="pr-3">
-              <div className="font-medium">Autofill login forms</div>
-              <div className="text-xs text-[color:var(--color-muted)]">
-                Auto-fills credentials and may submit detected login forms.
-              </div>
-            </div>
-            <Switch
-              checked={deviceState.autofillCredentialsEnabled}
-              onCheckedChange={(checked) => {
-                setSecuritySettings({
-                  autofillCredentialsEnabled: checked,
-                  autofillTOTPEnabled: deviceState.autofillTOTPEnabled,
-                  notificationOnVaultUnlock:
-                    deviceState.notificationOnVaultUnlock,
-                  notificationOnWrongPasswordAttempts:
-                    deviceState.notificationOnWrongPasswordAttempts,
-                  syncTOTP: deviceState.syncTOTP,
-                  uiLanguage: deviceState.uiLanguage,
-                  vaultLockTimeoutSeconds: deviceState.vaultLockTimeoutSeconds
-                })
-              }}
-            />
-          </label>
-        </div>
-      ) : null}
 
       <div className="mt-2 h-[300px] w-[350px] px-1">
         <div className="grid gap-3 pb-5">

--- a/web-extension/src/util/autofillCredentialsPreference.spec.ts
+++ b/web-extension/src/util/autofillCredentialsPreference.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import browser from 'webextension-polyfill'
+import {
+  AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY,
+  getAutofillCredentialsEnabled,
+  setAutofillCredentialsEnabled
+} from './autofillCredentialsPreference'
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      local: {
+        get: vi.fn(),
+        set: vi.fn()
+      }
+    }
+  }
+}))
+
+describe('autofill credentials preference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('defaults to enabled when no local preference exists', async () => {
+    vi.mocked(browser.storage.local.get).mockResolvedValue({})
+
+    await expect(getAutofillCredentialsEnabled()).resolves.toBe(true)
+  })
+
+  it('reads and writes the local preference', async () => {
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      [AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY]: false
+    })
+
+    await expect(getAutofillCredentialsEnabled()).resolves.toBe(false)
+
+    await setAutofillCredentialsEnabled(false)
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
+      [AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY]: false
+    })
+  })
+})

--- a/web-extension/src/util/autofillCredentialsPreference.ts
+++ b/web-extension/src/util/autofillCredentialsPreference.ts
@@ -1,0 +1,21 @@
+import browser from 'webextension-polyfill'
+
+export const AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY =
+  'autofillCredentialsEnabled'
+
+export const getAutofillCredentialsEnabled = async (): Promise<boolean> => {
+  const storage = await browser.storage.local.get(
+    AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY
+  )
+  const storedValue = storage[AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY]
+
+  return typeof storedValue === 'boolean' ? storedValue : true
+}
+
+export const setAutofillCredentialsEnabled = async (
+  enabled: boolean
+): Promise<void> => {
+  await browser.storage.local.set({
+    [AUTOFILL_CREDENTIALS_ENABLED_STORAGE_KEY]: enabled
+  })
+}

--- a/web-extension/src/util/autofillForbiddenUrlPatterns.spec.ts
+++ b/web-extension/src/util/autofillForbiddenUrlPatterns.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isAutofillForbiddenForUrl,
+  parseAutofillForbiddenUrlPatterns,
+  serializeAutofillForbiddenUrlPatterns
+} from '@shared/autofillForbiddenUrlPatterns'
+
+describe('autofill forbidden URL patterns', () => {
+  it('trims line-separated patterns and removes duplicates', () => {
+    expect(
+      parseAutofillForbiddenUrlPatterns(`
+        www.google.com/my-path/*
+        https://accounts.example.com/login/*
+        www.google.com/my-path/*
+      `)
+    ).toEqual([
+      'www.google.com/my-path/*',
+      'https://accounts.example.com/login/*'
+    ])
+
+    expect(
+      serializeAutofillForbiddenUrlPatterns(
+        'example.com/*\r\nexample.com/*\nfoo.test/private/*'
+      )
+    ).toBe('example.com/*\nfoo.test/private/*')
+  })
+
+  it('matches wildcard patterns against the full URL', () => {
+    const forbiddenUrlPatterns = [
+      'www.google.com/my-path/*',
+      'https://secure.example.com/*/login?next=*'
+    ].join('\n')
+
+    expect(
+      isAutofillForbiddenForUrl(
+        'https://www.google.com/my-path/account',
+        forbiddenUrlPatterns
+      )
+    ).toBe(true)
+    expect(
+      isAutofillForbiddenForUrl(
+        'http://www.google.com/my-path/account',
+        forbiddenUrlPatterns
+      )
+    ).toBe(true)
+    expect(
+      isAutofillForbiddenForUrl(
+        'https://www.google.com/another-path/account',
+        forbiddenUrlPatterns
+      )
+    ).toBe(false)
+    expect(
+      isAutofillForbiddenForUrl(
+        'https://secure.example.com/admin/login?next=/dashboard',
+        forbiddenUrlPatterns
+      )
+    ).toBe(true)
+    expect(
+      isAutofillForbiddenForUrl(
+        'http://secure.example.com/admin/login?next=/dashboard',
+        forbiddenUrlPatterns
+      )
+    ).toBe(false)
+  })
+
+  it('treats regex characters as URL literals', () => {
+    expect(
+      isAutofillForbiddenForUrl(
+        'https://example.com/search?query=password',
+        'https://example.com/search?query=*'
+      )
+    ).toBe(true)
+    expect(
+      isAutofillForbiddenForUrl(
+        'https://example.com/searchXquery=password',
+        'https://example.com/search?query=*'
+      )
+    ).toBe(false)
+  })
+})

--- a/web-extension/src/util/securitySettings.spec.ts
+++ b/web-extension/src/util/securitySettings.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { toBackendSettings } from './securitySettings'
+
+describe('security settings', () => {
+  it('omits the extension-only autofill toggle from backend settings', () => {
+    expect(
+      toBackendSettings({
+        autofillCredentialsEnabled: false,
+        autofillForbiddenUrlPatterns: 'example.com/private/*',
+        autofillTOTPEnabled: true,
+        notificationOnVaultUnlock: false,
+        notificationOnWrongPasswordAttempts: 3,
+        syncTOTP: true,
+        uiLanguage: 'en',
+        vaultLockTimeoutSeconds: 3600
+      })
+    ).toEqual({
+      autofillForbiddenUrlPatterns: 'example.com/private/*',
+      autofillTOTPEnabled: true,
+      notificationOnVaultUnlock: false,
+      notificationOnWrongPasswordAttempts: 3,
+      syncTOTP: true,
+      uiLanguage: 'en',
+      vaultLockTimeoutSeconds: 3600
+    })
+  })
+})

--- a/web-extension/src/util/securitySettings.ts
+++ b/web-extension/src/util/securitySettings.ts
@@ -1,0 +1,13 @@
+import type { SettingsInput } from '@shared/generated/graphqlBaseTypes'
+import type { SecuritySettings } from '@src/background/backgroundSchemas'
+
+export const toBackendSettings = (
+  settings: SecuritySettings
+): SettingsInput => {
+  const {
+    autofillCredentialsEnabled: _autofillCredentialsEnabled,
+    ...backendSettings
+  } = settings
+
+  return backendSettings
+}

--- a/web-extension/src/util/useDeviceState.tsx
+++ b/web-extension/src/util/useDeviceState.tsx
@@ -5,10 +5,8 @@ import {
   IBackgroundStateSerializable,
   IBackgroundStateSerializableLocked
 } from '@src/background/backgroundPage'
-import {
-  EncryptedSecretType,
-  SettingsInput
-} from '../../../shared/generated/graphqlBaseTypes'
+import { EncryptedSecretType } from '../../../shared/generated/graphqlBaseTypes'
+import type { SecuritySettings } from '@src/background/backgroundSchemas'
 import debug from 'debug'
 import {
   device,
@@ -140,8 +138,8 @@ export function useDeviceState() {
     [deviceState?.decryptedSecrets]
   )
 
-  const setSecuritySettings = useCallback(async (config: SettingsInput) => {
-    device.setDeviceSettings(config)
+  const setSecuritySettings = useCallback(async (config: SecuritySettings) => {
+    await device.setDeviceSettings(config)
   }, [])
 
   const saveDeviceState = useCallback(


### PR DESCRIPTION
## What changed

- Stores the credential-autofill toggle locally in each browser extension, rather than syncing it as a device setting.
- Adds an account-wide “Never autofill on” list with one wildcard URL pattern per line, enforced before a content script enables autofill.
- Removes the obsolete credential-autofill fields from device/default settings and updates GraphQL clients, registration, login, and settings flows.
- Adds the generated migration that moves URL exclusions onto the user record and drops the legacy columns.

## Why

Credential autofill is a browser-specific preference, while URL exclusions need to apply consistently across a user’s devices.

## User impact

Users can turn credential autofill on or off for the current browser without affecting other devices, and can prevent autofill on selected URLs everywhere.

## Validation

- `web-extension/src/util/autofillCredentialsPreference.spec.ts`
- `web-extension/src/util/autofillForbiddenUrlPatterns.spec.ts`
- `web-extension/src/util/securitySettings.spec.ts`
- `backend/models/UserMutation.spec.ts`

All focused tests pass (10 passing tests; 3 pre-existing backend todos). Full package type checks remain blocked by unresolved local dependencies (including Lingui, ORPC, and RxJS module-resolution issues), none of which originate in this change.