### PR TITLE
Add canonical homepage to extension manifests

### DIFF
--- a/web-extension/package.json
+++ b/web-extension/package.json
@@ -3,6 +3,7 @@
   "displayName": "Authier",
   "version": "1.2.9",
   "description": "Authier web Extension for all our supported browsers",
+  "homepage": "https://www.authier.pm/",
   "license": "AGPL-3.0-or-later",
   "webExt": {
     "sourceDir": "dist/"

--- a/web-extension/src/manifest.ts
+++ b/web-extension/src/manifest.ts
@@ -23,6 +23,7 @@ function getFirefoxManifestV2(
     name: pkg.displayName,
     version: pkg.version,
     description: 'Authier password manager firefox extension',
+    homepage_url: pkg.homepage,
     browser_action: {
       default_icon: 'icon-16.png',
       default_popup: 'js/popup.html'
@@ -84,6 +85,7 @@ export async function getManifest() {
     name: pkg.displayName,
     version: pkg.version,
     description: pkg.description,
+    homepage_url: pkg.homepage,
     action: {
       default_icon: {
         16: 'icon-16.png',


### PR DESCRIPTION
## Summary

- add the canonical Authier homepage to the extension package metadata
- expose it through `homepage_url` in both Firefox Manifest V2 and Chromium Manifest V3 builds
- give browser marketplaces a stable first-party website reference

## Verification

- `pnpm --dir web-extension tsc`
- generated Manifest V3 and confirmed `homepage_url`
- generated Manifest V2 and confirmed `homepage_url`

The clean-worktree dependency reinstall later hit the host tmpfs inode limit, but the identical patch passed the checks above in the primary workspace.