### PR TITLE
feat: publish autofill safety corpus

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,6 +10,7 @@
     "node_modules/*",
     "*.snap",
     "**/*.codegen.*",
+    "landing-page/public/research/autofill-safety-corpus-v1.json",
     "pnpm-lock.yaml"
   ]
 }

--- a/landing-page/public/.well-known/security.txt
+++ b/landing-page/public/.well-known/security.txt
@@ -1,6 +1,6 @@
-Contact: mailto:authier.ml@google.com
+Contact: mailto:authier.ml@gmail.com
 Contact: https://github.com/authier-pm/authier/security/policy
-Encryption: https://keys.openpgp.org/search?q=0xDE6887086F892325FEC04CC0D847525B6931381F
+Encryption: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xDE6887086F892325FEC04CC0D847525B6931381F
 Policy: https://github.com/authier-pm/authier/blob/main/SECURITY.md
 Canonical: https://www.authier.pm/.well-known/security.txt
 Expires: 2027-08-31T23:59:59Z

--- a/landing-page/public/research/autofill-safety-corpus-v1.json
+++ b/landing-page/public/research/autofill-safety-corpus-v1.json
@@ -101,7 +101,9 @@
             "passwordKind": "none",
             "storedPasswordTargetId": null,
             "otpKind": "single",
-            "otpTargetIds": ["verification-code"]
+            "otpTargetIds": [
+              "verification-code"
+            ]
           }
         },
         {
@@ -252,7 +254,9 @@
             "passwordKind": "none",
             "storedPasswordTargetId": null,
             "otpKind": "single",
-            "otpTargetIds": ["session-otp"]
+            "otpTargetIds": [
+              "session-otp"
+            ]
           }
         }
       ]

--- a/landing-page/public/research/autofill-safety-corpus-v1.json
+++ b/landing-page/public/research/autofill-safety-corpus-v1.json
@@ -1,0 +1,261 @@
+{
+  "name": "Open Autofill Safety Corpus",
+  "version": "1.0.0",
+  "license": "AGPL-3.0-or-later",
+  "licenseUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+  "limitations": [
+    "All markup is synthetic and deliberately small; it is not copied from vendor pages.",
+    "The corpus does not exercise a live browser, browser-extension permissions, cross-browser behavior, network requests, form submission, or real secrets.",
+    "Passing the corpus is not a security audit, a compatibility guarantee, or evidence of a measured false-positive rate.",
+    "Version 1 does not cover cross-origin frames, closed shadow roots, localization heuristics, visual layout, or hostile page scripts."
+  ],
+  "fixtures": [
+    {
+      "id": "password-only-login",
+      "title": "Password-only step in a multi-step login",
+      "category": "password-only-login",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-current-password-step",
+          "description": "A current-password field remains a login target when the username was collected on an earlier page.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/sign-in/challenge",
+            "bodyHtml": "\n              <main>\n                <h1>Welcome back</h1>\n                <form id=\"password-step\">\n                  <input\n                    id=\"login-password\"\n                    type=\"password\"\n                    autocomplete=\"current-password\"\n                  />\n                  <button type=\"submit\">Continue</button>\n                </form>\n              </main>\n            "
+          },
+          "expected": {
+            "passwordKind": "login",
+            "storedPasswordTargetId": "login-password",
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "signup-no-fill",
+      "title": "Signup fields are not stored-password targets",
+      "category": "signup-no-fill",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-new-password-pair",
+          "description": "Two explicit new-password fields must not receive an existing stored password.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/join",
+            "bodyHtml": "\n              <form id=\"signup-form\">\n                <input id=\"signup-email\" type=\"email\" autocomplete=\"username\" />\n                <input id=\"signup-password\" type=\"password\" autocomplete=\"new-password\" />\n                <input id=\"signup-password-confirmation\" type=\"password\" autocomplete=\"new-password\" />\n                <button type=\"submit\">Create account</button>\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "signup",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "change-password-no-fill",
+      "title": "Change-password forms are not login autofill targets",
+      "category": "change-password-no-fill",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-current-and-new-passwords",
+          "description": "A settings form can identify the existing-password field without authorizing automatic credential fill.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/account/security",
+            "bodyHtml": "\n              <main>\n                <h1>Change password</h1>\n                <form id=\"change-password-form\">\n                  <input id=\"old-password\" type=\"password\" autocomplete=\"current-password\" />\n                  <input id=\"new-password\" type=\"password\" autocomplete=\"new-password\" />\n                  <input id=\"new-password-confirmation\" type=\"password\" autocomplete=\"new-password\" />\n                  <button type=\"submit\">Update password</button>\n                </form>\n              </main>\n            "
+          },
+          "expected": {
+            "passwordKind": "change-password",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "otp-versus-code-traps",
+      "title": "OTP fields are separated from recovery and payment codes",
+      "category": "otp-versus-code-traps",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-single-otp",
+          "description": "An explicit one-time-code field is a TOTP target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/sign-in/verify",
+            "bodyHtml": "\n              <form id=\"verification-form\">\n                <label for=\"verification-code\">Authentication code</label>\n                <input\n                  id=\"verification-code\"\n                  name=\"mfa_code\"\n                  type=\"text\"\n                  inputmode=\"numeric\"\n                  maxlength=\"6\"\n                  autocomplete=\"one-time-code\"\n                />\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "single",
+            "otpTargetIds": ["verification-code"]
+          }
+        },
+        {
+          "id": "02-segmented-otp",
+          "description": "A corroborated six-box verification widget is an ordered TOTP target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/sign-in/verify-boxes",
+            "bodyHtml": "\n              <div id=\"otp-code-widget\">\n                <input id=\"otp-1\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 1\" />\n                <input id=\"otp-2\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 2\" />\n                <input id=\"otp-3\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 3\" />\n                <input id=\"otp-4\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 4\" />\n                <input id=\"otp-5\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 5\" />\n                <input id=\"otp-6\" class=\"otp-box\" type=\"text\" inputmode=\"numeric\" maxlength=\"1\" aria-label=\"Digit 6\" />\n              </div>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "segmented",
+            "otpTargetIds": [
+              "otp-1",
+              "otp-2",
+              "otp-3",
+              "otp-4",
+              "otp-5",
+              "otp-6"
+            ]
+          }
+        },
+        {
+          "id": "03-recovery-code-trap",
+          "description": "A recovery-code field stays excluded even when misleading markup advertises one-time-code.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/account/recovery",
+            "bodyHtml": "\n              <form id=\"recovery-form\">\n                <label for=\"recovery-code\">Recovery code</label>\n                <input\n                  id=\"recovery-code\"\n                  name=\"recovery_code\"\n                  type=\"text\"\n                  inputmode=\"numeric\"\n                  maxlength=\"10\"\n                  autocomplete=\"one-time-code\"\n                />\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        },
+        {
+          "id": "04-card-security-code-trap",
+          "description": "A card verification value is payment data, not a one-time authentication code.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/checkout",
+            "bodyHtml": "\n              <form id=\"payment-form\">\n                <label for=\"card-security-code\">Card security code</label>\n                <input\n                  id=\"card-security-code\"\n                  name=\"cvv\"\n                  type=\"text\"\n                  inputmode=\"numeric\"\n                  maxlength=\"3\"\n                  autocomplete=\"cc-csc\"\n                />\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "ambiguity",
+      "title": "Ambiguous targets cause abstention",
+      "category": "ambiguity",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-unannotated-password-form",
+          "description": "An unannotated password form without decisive context is not treated as a login target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/access",
+            "bodyHtml": "\n              <form id=\"ambiguous-password-form\">\n                <input id=\"account-alias\" type=\"text\" name=\"account-alias\" />\n                <input id=\"ambiguous-password\" type=\"password\" />\n                <button type=\"submit\">Proceed</button>\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "unknown",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        },
+        {
+          "id": "02-two-equally-plausible-otp-fields",
+          "description": "Two equally scored OTP candidates are not resolved by DOM order.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/verify-choice",
+            "bodyHtml": "\n              <form id=\"ambiguous-code-form\">\n                <input id=\"verification-left\" name=\"mfa_code_left\" type=\"text\" inputmode=\"numeric\" maxlength=\"6\" />\n                <input id=\"verification-right\" name=\"mfa_code_right\" type=\"text\" inputmode=\"numeric\" maxlength=\"6\" />\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "dynamic-replacement",
+      "title": "Multi-step authentication replaces its inputs",
+      "category": "dynamic-replacement",
+      "provenance": "synthetic",
+      "phases": [
+        {
+          "id": "01-identifier-step",
+          "description": "The first DOM has an identifier and no secret target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/session/identifier",
+            "bodyHtml": "\n              <form id=\"session-step\">\n                <input id=\"session-identifier\" type=\"email\" autocomplete=\"username\" />\n                <button type=\"submit\">Continue</button>\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        },
+        {
+          "id": "02-password-step",
+          "description": "After replacement, the newly queried current-password node is the login target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/session/password",
+            "bodyHtml": "\n              <form id=\"session-step\">\n                <input id=\"session-password\" type=\"password\" autocomplete=\"current-password\" />\n                <button type=\"submit\">Continue</button>\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "login",
+            "storedPasswordTargetId": "session-password",
+            "otpKind": "none",
+            "otpTargetIds": []
+          }
+        },
+        {
+          "id": "03-otp-step",
+          "description": "A second replacement removes the password target and introduces a fresh OTP target.",
+          "document": {
+            "language": "en",
+            "otpCodeLength": 6,
+            "url": "https://synthetic.invalid/session/otp",
+            "bodyHtml": "\n              <form id=\"session-step\">\n                <input\n                  id=\"session-otp\"\n                  name=\"otp_code\"\n                  type=\"text\"\n                  inputmode=\"numeric\"\n                  maxlength=\"6\"\n                  autocomplete=\"one-time-code\"\n                />\n                <button type=\"submit\">Verify</button>\n              </form>\n            "
+          },
+          "expected": {
+            "passwordKind": "none",
+            "storedPasswordTargetId": null,
+            "otpKind": "single",
+            "otpTargetIds": ["session-otp"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/landing-page/public/research/autofill-safety-corpus-v1.sha256
+++ b/landing-page/public/research/autofill-safety-corpus-v1.sha256
@@ -1,0 +1,1 @@
+d29d8fdfbfe826216efd1118e4326af99559c1c24388e0d8111608c1c2d402a7  autofill-safety-corpus-v1.json

--- a/landing-page/scripts/checkSeo.ts
+++ b/landing-page/scripts/checkSeo.ts
@@ -1,9 +1,21 @@
+import { createHash } from 'node:crypto'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const projectDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const distributionDirectory = join(projectDirectory, 'dist')
+const publicContactEmail = 'authier.ml@gmail.com'
+const obsoletePublicContactEmail = 'authier.ml@google.com'
+const encryptionKeyUrl =
+  'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xDE6887086F892325FEC04CC0D847525B6931381F'
+const corpusFileName = 'autofill-safety-corpus-v1.json'
+const corpusAssetPath = join(distributionDirectory, 'research', corpusFileName)
+const corpusChecksumPath = join(
+  distributionDirectory,
+  'research',
+  'autofill-safety-corpus-v1.sha256'
+)
 
 function listHtmlFiles(directory: string): string[] {
   return readdirSync(directory).flatMap((entry) => {
@@ -69,6 +81,10 @@ for (const file of files) {
   )
   const h1Count = html.match(/<h1(?:\s|>)/gi)?.length ?? 0
 
+  if (html.includes(obsoletePublicContactEmail)) {
+    throw new Error(`${route}: contains the obsolete project contact address`)
+  }
+
   if (h1Count !== 1) {
     throw new Error(`${route}: expected exactly one h1, found ${h1Count}`)
   }
@@ -122,7 +138,9 @@ for (const file of files) {
     const target = href.split(/[?#]/, 1)[0]?.replace(/\/$/, '') || '/'
     internalLinks += 1
 
-    if (!routes.has(target)) {
+    const assetPath = join(distributionDirectory, target.slice(1))
+
+    if (!routes.has(target) && !existsSync(assetPath)) {
       throw new Error(`${route}: internal link target does not exist: ${href}`)
     }
   }
@@ -145,6 +163,47 @@ for (const requiredFile of [
   if (!existsSync(join(distributionDirectory, requiredFile))) {
     throw new Error(`Missing SEO or platform file: ${requiredFile}`)
   }
+}
+
+const securityContact = readFileSync(
+  join(distributionDirectory, '.well-known/security.txt'),
+  'utf8'
+)
+
+if (!securityContact.includes(`Contact: mailto:${publicContactEmail}`)) {
+  throw new Error('security.txt is missing the canonical project email contact')
+}
+
+if (!securityContact.includes(`Encryption: ${encryptionKeyUrl}`)) {
+  throw new Error('security.txt is missing the working public encryption key')
+}
+
+if (securityContact.includes(obsoletePublicContactEmail)) {
+  throw new Error('security.txt contains the obsolete project contact address')
+}
+
+const corpusContents = readFileSync(corpusAssetPath)
+const corpusSha256 = createHash('sha256').update(corpusContents).digest('hex')
+const checksumContents = readFileSync(corpusChecksumPath, 'utf8')
+const expectedChecksumContents = `${corpusSha256}  ${corpusFileName}\n`
+
+JSON.parse(corpusContents.toString('utf8'))
+
+if (checksumContents !== expectedChecksumContents) {
+  throw new Error('Autofill corpus SHA-256 sidecar is stale or malformed')
+}
+
+const corpusPage = readFileSync(
+  join(distributionDirectory, 'research', 'autofill-safety-corpus.html'),
+  'utf8'
+)
+
+if (!corpusPage.includes(corpusSha256)) {
+  throw new Error('Autofill corpus page does not publish the current SHA-256')
+}
+
+if (!corpusPage.includes('href="/research/autofill-safety-corpus-v1.sha256"')) {
+  throw new Error('Autofill corpus page does not link its SHA-256 sidecar')
 }
 
 const sitemap = readFileSync(

--- a/landing-page/src/components/Footer.astro
+++ b/landing-page/src/components/Footer.astro
@@ -25,6 +25,7 @@ import { navigation, site } from '../config'
       <nav aria-label="Resource links">
         <a href="/faq">FAQ</a>
         <a href="/guides">Guides</a>
+        <a href="/research">Research</a>
         <a href="/blog">Blog</a>
         <a href={site.githubUrl} target="_blank" rel="noreferrer">Source code</a>
         <a href={site.statusUrl} target="_blank" rel="noreferrer">Service status</a>
@@ -43,7 +44,7 @@ import { navigation, site } from '../config'
   </div>
   <div class="shell footer-bottom">
     <p>© {new Date().getFullYear()} Authier contributors.</p>
-    <p>Open source under AGPL-3.0.</p>
+    <p>Open source under AGPL-3.0-or-later.</p>
   </div>
 </footer>
 

--- a/landing-page/src/config.ts
+++ b/landing-page/src/config.ts
@@ -29,5 +29,6 @@ export const navigation = [
   { label: 'Security', href: '/security' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'Guides', href: '/guides' },
+  { label: 'Research', href: '/research' },
   { label: 'Blog', href: '/blog' }
 ] as const

--- a/landing-page/src/data/blog.ts
+++ b/landing-page/src/data/blog.ts
@@ -1,12 +1,6 @@
-export interface BlogPost {
-  title: string
-  description: string
-  href: string
-  publishedAt: string
-  updatedAt: string
-  readingTime: string
-  category: string
-}
+import type { ContentEntry } from './content'
+
+export type BlogPost = ContentEntry
 
 export const blogPosts = [
   {

--- a/landing-page/src/data/content.ts
+++ b/landing-page/src/data/content.ts
@@ -1,0 +1,9 @@
+export interface ContentEntry {
+  title: string
+  description: string
+  href: string
+  publishedAt: string
+  updatedAt: string
+  readingTime: string
+  category: string
+}

--- a/landing-page/src/data/guides.ts
+++ b/landing-page/src/data/guides.ts
@@ -1,12 +1,6 @@
-export interface Guide {
-  title: string
-  description: string
-  href: string
-  publishedAt: string
-  updatedAt: string
-  readingTime: string
-  category: string
-}
+import type { ContentEntry } from './content'
+
+export type Guide = ContentEntry
 
 export const guides = [
   {

--- a/landing-page/src/data/guides.ts
+++ b/landing-page/src/data/guides.ts
@@ -2,6 +2,7 @@ export interface Guide {
   title: string
   description: string
   href: string
+  publishedAt: string
   updatedAt: string
   readingTime: string
   category: string
@@ -13,6 +14,7 @@ export const guides = [
     description:
       'Learn how a password manager with built-in TOTP works, when one vault is convenient, and when separating your second factor is the safer choice.',
     href: '/guides/password-manager-with-2fa',
+    publishedAt: '2026-08-31',
     updatedAt: '2026-08-31',
     readingTime: '8 min read',
     category: 'Two-factor authentication'
@@ -22,6 +24,7 @@ export const guides = [
     description:
       'Understand how trusted-device approval changes new-device enrollment, what it can block, and which endpoint risks it cannot remove.',
     href: '/guides/trusted-device-approval',
+    publishedAt: '2026-08-31',
     updatedAt: '2026-08-31',
     readingTime: '7 min read',
     category: 'Security model'
@@ -31,6 +34,7 @@ export const guides = [
     description:
       'Compare the security, autofill, platform, recovery, export, and audit questions that matter when choosing a browser password manager.',
     href: '/guides/browser-password-manager',
+    publishedAt: '2026-08-31',
     updatedAt: '2026-08-31',
     readingTime: '9 min read',
     category: 'Buying guide'
@@ -40,6 +44,7 @@ export const guides = [
     description:
       'Plan a safer password-manager migration with CSV and JSON exports, duplicate checks, verification steps, and secure cleanup of plaintext files.',
     href: '/guides/password-manager-import-export',
+    publishedAt: '2026-08-31',
     updatedAt: '2026-08-31',
     readingTime: '8 min read',
     category: 'Migration guide'

--- a/landing-page/src/data/research.ts
+++ b/landing-page/src/data/research.ts
@@ -1,0 +1,16 @@
+import type { ContentEntry } from './content'
+
+export type ResearchArtifact = ContentEntry
+
+export const researchArtifacts = [
+  {
+    title: 'Open Autofill Safety Corpus v1',
+    description:
+      'A typed, machine-readable set of synthetic login, password-change, OTP, ambiguity, and dynamic-form cases for testing conservative autofill decisions.',
+    href: '/research/autofill-safety-corpus',
+    publishedAt: '2026-09-01',
+    updatedAt: '2026-09-01',
+    readingTime: '7 min read',
+    category: 'Research artifact'
+  }
+] as const satisfies readonly ResearchArtifact[]

--- a/landing-page/src/layouts/BaseLayout.astro
+++ b/landing-page/src/layouts/BaseLayout.astro
@@ -55,7 +55,7 @@ const fullTitle = title === site.name ? title : `${title} | ${site.name}`
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="Authier articles and guides"
+      title="Authier articles, guides, and research"
       href="/rss.xml"
     />
     <meta name="theme-color" content="#070a0a" />

--- a/landing-page/src/layouts/BaseLayout.astro
+++ b/landing-page/src/layouts/BaseLayout.astro
@@ -55,7 +55,7 @@ const fullTitle = title === site.name ? title : `${title} | ${site.name}`
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="Authier password manager blog"
+      title="Authier articles and guides"
       href="/rss.xml"
     />
     <meta name="theme-color" content="#070a0a" />

--- a/landing-page/src/pages/privacy-policy.astro
+++ b/landing-page/src/pages/privacy-policy.astro
@@ -271,7 +271,7 @@ const schema = {
 
     <p>
       Privacy questions or requests can be sent to
-      <a href="mailto:authier.ml@google.com">authier.ml@google.com</a>. Security
+      <a href="mailto:authier.ml@gmail.com">authier.ml@gmail.com</a>. Security
       vulnerabilities should follow the responsible-disclosure process in the
       <a href="https://github.com/authier-pm/authier/blob/main/SECURITY.md">Authier security policy</a>.
     </p>

--- a/landing-page/src/pages/research/autofill-safety-corpus.astro
+++ b/landing-page/src/pages/research/autofill-safety-corpus.astro
@@ -1,0 +1,366 @@
+---
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { site } from '../../config'
+import { researchArtifacts } from '../../data/research'
+import ArticleLayout from '../../layouts/ArticleLayout.astro'
+
+const [artifact] = researchArtifacts
+const corpusUrl = '/research/autofill-safety-corpus-v1.json'
+const checksumUrl = '/research/autofill-safety-corpus-v1.sha256'
+const sourceUrl = `${site.githubUrl}/tree/main/research/autofill-safety`
+const adapterUrl = `${site.githubUrl}/blob/main/web-extension/src/content-script/autofillSafetyCorpus.spec.ts`
+const corpusFileUrl = new URL(
+  '../../../public/research/autofill-safety-corpus-v1.json',
+  import.meta.url
+)
+const corpusSha256 = createHash('sha256')
+  .update(readFileSync(corpusFileUrl))
+  .digest('hex')
+
+const datasetSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Dataset',
+  name: artifact.title,
+  description: artifact.description,
+  url: `${site.url}${artifact.href}`,
+  version: '1.0.0',
+  datePublished: artifact.publishedAt,
+  dateModified: artifact.updatedAt,
+  creator: {
+    '@type': 'Organization',
+    name: 'Authier contributors',
+    url: site.githubUrl
+  },
+  license: 'https://spdx.org/licenses/AGPL-3.0-or-later.html',
+  measurementTechnique: 'Synthetic jsdom classifier adapter tests',
+  keywords: [
+    'password manager',
+    'autofill',
+    'TOTP',
+    'browser extension',
+    'form classification'
+  ],
+  distribution: {
+    '@type': 'DataDownload',
+    contentUrl: `${site.url}${corpusUrl}`,
+    encodingFormat: 'application/json',
+    sha256: corpusSha256
+  }
+}
+---
+
+<ArticleLayout
+  title={artifact.title}
+  description={artifact.description}
+  publishedAt={artifact.publishedAt}
+  updatedAt={artifact.updatedAt}
+  readingTime={artifact.readingTime}
+  collectionHref="/research"
+  collectionLabel="Research"
+  eyebrow="Open research artifact"
+  schemaType="TechArticle"
+  extraSchema={[datasetSchema]}
+>
+  <div class="article-callout">
+    <p><strong>Read the scope first:</strong> this is a synthetic jsdom classifier corpus. It is not a live-browser benchmark, a security audit, a compatibility guarantee, or a measured false-positive study.</p>
+  </div>
+
+  <p>
+    Password-manager autofill is a write decision involving a secret. A useful
+    test contract therefore needs to express not only where a credential may go,
+    but also when the safest answer is <strong>no target</strong>. Open Autofill
+    Safety Corpus v1 turns that narrow decision into typed, machine-readable
+    fixtures with exact expected element IDs.
+  </p>
+
+  <div class="corpus-metrics" aria-label="Corpus scope">
+    <div><strong>6</strong><span>synthetic fixtures</span></div>
+    <div><strong>12</strong><span>deterministic phases</span></div>
+    <div><strong>0</strong><span>real credentials</span></div>
+    <div><strong>v1</strong><span>classifier contract</span></div>
+  </div>
+
+  <p class="corpus-actions">
+    <a class="button" href={corpusUrl} download>Download corpus JSON</a>
+    <a class="button button-secondary" href={checksumUrl} download>Download SHA-256</a>
+    <a class="button button-secondary" href={sourceUrl} target="_blank" rel="noreferrer">Inspect typed source</a>
+  </p>
+
+  <p class="corpus-checksum">
+    <span>SHA-256</span>
+    <code>{corpusSha256}</code>
+  </p>
+
+  <h2>What version 1 contains</h2>
+
+  <p>
+    Every fixture uses small, hand-written markup on a reserved
+    <code>.invalid</code> hostname. No HTML is copied from a real vendor page.
+    A phase records the URL, document language, body markup, expected password
+    classification, optional stored-password target, OTP shape, and ordered OTP
+    targets.
+  </p>
+
+  <div
+    class="corpus-table-wrap"
+    tabindex="0"
+    aria-label="Scrollable corpus fixture summary"
+  >
+    <table>
+      <caption>Open Autofill Safety Corpus v1 fixture summary</caption>
+      <thead>
+        <tr>
+          <th scope="col">Fixture</th>
+          <th scope="col">Phases</th>
+          <th scope="col">Safety expectation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Password-only login</td>
+          <td>1</td>
+          <td>Recognize an explicit current-password step after the identifier was collected elsewhere.</td>
+        </tr>
+        <tr>
+          <td>Signup no-fill</td>
+          <td>1</td>
+          <td>Classify new-password fields without selecting a stored-password target.</td>
+        </tr>
+        <tr>
+          <td>Change-password no-fill</td>
+          <td>1</td>
+          <td>Identify the form kind while withholding automatic stored-credential fill.</td>
+        </tr>
+        <tr>
+          <td>OTP versus code traps</td>
+          <td>4</td>
+          <td>Accept explicit single and segmented OTPs; reject recovery and card-security codes.</td>
+        </tr>
+        <tr>
+          <td>Ambiguity</td>
+          <td>2</td>
+          <td>Abstain on an unannotated password form and equally plausible OTP candidates.</td>
+        </tr>
+        <tr>
+          <td>Dynamic replacement</td>
+          <td>3</td>
+          <td>Re-query identifier, password, and OTP nodes as a synthetic multi-step flow changes shape.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>How the contract runs</h2>
+
+  <ol>
+    <li>The runner sorts fixtures and phases by stable identifiers.</li>
+    <li>An adapter mounts the synthetic document for one phase.</li>
+    <li>The adapter returns a normalized observation rather than performing a credential write.</li>
+    <li>The runner compares the password kind, password target, OTP kind, and ordered OTP targets exactly.</li>
+    <li>The report contains no clock time, random value, or environment-specific path, so identical observations serialize identically.</li>
+  </ol>
+
+  <p>
+    Authier’s repository adapter calls the production
+    <code>classifyPasswordForm</code>, <code>findSegmentedOtpInputs</code>, and
+    <code>findSingleOtpInput</code> functions, plus the same pure stored-password
+    target policy used by runtime autofill. The
+    <a href={adapterUrl} target="_blank" rel="noreferrer">adapter test</a>
+    asserts exact observations without writing a credential. Separate
+    production suites exercise runtime autofill behavior with synthetic values.
+    This page does not publish a dated run report, so it does not present a
+    versioned empirical result, browser-compatibility measurement, or current
+    pass count.
+  </p>
+
+  <h2>What a passing result does not establish</h2>
+
+  <ul>
+    <li>No real browser or packaged extension is launched.</li>
+    <li>No password or TOTP value is written, submitted, or sent over a network.</li>
+    <li>No extension permission, content-script isolation, or hostile page script is exercised.</li>
+    <li>No cross-browser, cross-origin frame, closed-shadow-root, localization, or visual-layout behavior is measured.</li>
+    <li>No inference can be made about Authier’s overall security, compatibility, or real-world false-positive rate.</li>
+  </ul>
+
+  <p>
+    Authier remains early-stage and has not published an independent security
+    audit. Its broader <a href="/security">security architecture and limitations</a>
+    should be evaluated separately from this classifier artifact.
+  </p>
+
+  <h2>How this differs from existing work</h2>
+
+  <p>
+    This is not the first autofill test collection or password-manager study.
+    Mozilla maintains
+    <a href="https://github.com/mozilla/form-fill-examples" target="_blank" rel="noreferrer">form-fill example pages</a>,
+    while Bitwarden’s
+    <a href="https://github.com/bitwarden/browser-interactions-testing" target="_blank" rel="noreferrer">Browser Interactions Testing</a>
+    runs static and selected live scenarios with a real extension build. The
+    2020 USENIX Security paper
+    <a href="https://www.usenix.org/conference/usenixsecurity20/presentation/oesch" target="_blank" rel="noreferrer">“That Was Then, This Is Now”</a>
+    evaluated generation, storage, and autofill across 13 password managers.
+    The ACSAC 2024
+    <a href="https://github.com/Leaky-Autofill/LeakyAutofill-Artifact" target="_blank" rel="noreferrer">Leaky Autofill artifact</a>
+    examines whether password managers fill data into concealed fields.
+  </p>
+
+  <p>
+    Version 1 is intentionally smaller: an adapter-friendly regression contract
+    for form-shape classification, ordered target selection, and explicit
+    abstention. Its value is the narrow boundary, not a claim to replace
+    browser-level or empirical security research.
+  </p>
+
+  <h2>Next evidence layers</h2>
+
+  <p>
+    The next useful addition is a packaged-extension integration adapter in a
+    real Chromium context, followed by focused open-shadow-root coverage and
+    synthetic cross-origin-frame cases. Browser engines, localization, hostile
+    scripts, and a measured sample of real form shapes should remain separate
+    result sets so their evidence is not blurred into the deterministic v1
+    classifier contract.
+  </p>
+
+  <div class="article-callout">
+    <p><strong>Reproduce it:</strong> download the JSON, inspect the typed runner and Authier adapter, and report mismatches with the smallest synthetic form that demonstrates them. Do not submit real credentials or captured private pages.</p>
+  </div>
+</ArticleLayout>
+
+<style>
+  .corpus-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin: 38px 0;
+  }
+
+  .corpus-metrics div {
+    display: grid;
+    gap: 8px;
+    padding: 20px;
+    border: 1px solid var(--border-strong);
+    border-radius: 14px;
+    background: rgba(105, 230, 204, 0.035);
+  }
+
+  .corpus-metrics strong {
+    color: var(--text);
+    font-size: 1.75rem;
+    letter-spacing: -0.04em;
+  }
+
+  .corpus-metrics span {
+    color: var(--text-subtle);
+    font-size: 0.72rem;
+    line-height: 1.45;
+  }
+
+  .corpus-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .corpus-actions a {
+    text-decoration: none;
+  }
+
+  .corpus-actions .button {
+    color: #07110f;
+  }
+
+  .corpus-actions .button-secondary {
+    color: var(--text);
+  }
+
+  .corpus-checksum {
+    display: grid;
+    gap: 7px;
+    padding: 16px 18px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.018);
+  }
+
+  .corpus-checksum span {
+    color: var(--text-subtle);
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+
+  .corpus-checksum code {
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+  }
+
+  .corpus-table-wrap {
+    overflow-x: auto;
+    margin: 30px 0 42px;
+    border: 1px solid var(--border-strong);
+    border-radius: 14px;
+  }
+
+  .corpus-table-wrap:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.84rem;
+    line-height: 1.6;
+  }
+
+  caption {
+    padding: 14px 18px;
+    color: var(--text-muted);
+    font-size: 0.74rem;
+    font-weight: 640;
+    text-align: left;
+  }
+
+  th,
+  td {
+    padding: 16px 18px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.025);
+    font-size: 0.68rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  td:first-child {
+    min-width: 170px;
+    color: var(--text);
+    font-weight: 640;
+  }
+
+  td:nth-child(2) {
+    color: var(--accent);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  @media (max-width: 720px) {
+    .corpus-metrics {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/landing-page/src/pages/research/index.astro
+++ b/landing-page/src/pages/research/index.astro
@@ -2,76 +2,60 @@
 import Icon from '../../components/Icon.astro'
 import PageHero from '../../components/PageHero.astro'
 import { site } from '../../config'
-import { blogPosts } from '../../data/blog'
 import { researchArtifacts } from '../../data/research'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 
-const title = 'Password Manager Blog'
+const title = 'Password Manager Research'
 const description =
-  'Read Authier articles and research about password security, trusted devices, open-source development, TOTP authentication, and autofill safety.'
-
-const entries = [...researchArtifacts, ...blogPosts].sort(
-  (left, right) =>
-    new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
-)
+  'Inspect Authier’s reproducible password-manager research artifacts, machine-readable test cases, methods, results, and explicit limitations.'
 
 const schema = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
-  name: 'Authier password manager blog',
+  name: 'Authier password manager research',
   description,
-  url: `${site.url}/blog`,
-  hasPart: [
-    ...researchArtifacts.map((artifact) => ({
-      '@type': 'Dataset',
-      name: artifact.title,
-      description: artifact.description,
-      url: `${site.url}${artifact.href}`,
-      datePublished: artifact.publishedAt,
-      dateModified: artifact.updatedAt
-    })),
-    ...blogPosts.map((post) => ({
-      '@type': 'Article',
-      headline: post.title,
-      description: post.description,
-      url: `${site.url}${post.href}`,
-      datePublished: post.publishedAt,
-      dateModified: post.updatedAt
-    }))
-  ]
+  url: `${site.url}/research`,
+  hasPart: researchArtifacts.map((artifact) => ({
+    '@type': 'Dataset',
+    name: artifact.title,
+    description: artifact.description,
+    url: `${site.url}${artifact.href}`,
+    datePublished: artifact.publishedAt,
+    dateModified: artifact.updatedAt
+  }))
 }
 ---
 
 <BaseLayout title={title} description={description} schema={schema}>
   <PageHero
-    eyebrow="Authier journal"
-    title="Security notes from an open project."
+    eyebrow="Open research"
+    title="Evidence you can rerun. Limits you can see."
     description={description}
     breadcrumbs={[
       { label: 'Home', href: '/' },
-      { label: 'Blog' }
+      { label: 'Research' }
     ]}
     compact
   />
 
-  <section class="section shell posts">
-    {entries.map((post, index) => (
-      <article class:list={['post-card', 'card', { featured: index === 0 }]}>
-        <div class="post-meta">
-          <span>{post.category}</span>
-          <time datetime={post.updatedAt}>
+  <section class="section shell research-list">
+    {researchArtifacts.map((artifact) => (
+      <article class="research-card card">
+        <div class="research-meta">
+          <span>{artifact.category}</span>
+          <time datetime={artifact.updatedAt}>
             {new Intl.DateTimeFormat('en', {
               month: 'short',
               day: 'numeric',
               year: 'numeric',
               timeZone: 'UTC'
-            }).format(new Date(post.updatedAt))}
+            }).format(new Date(artifact.updatedAt))}
           </time>
         </div>
-        <h2><a href={post.href}>{post.title}</a></h2>
-        <p>{post.description}</p>
-        <a class="read-link" href={post.href}>
-          Read article
+        <h2><a href={artifact.href}>{artifact.title}</a></h2>
+        <p>{artifact.description}</p>
+        <a class="read-link" href={artifact.href}>
+          Inspect artifact
           <Icon name="arrow" size={18} />
         </a>
       </article>
@@ -80,26 +64,22 @@ const schema = {
 </BaseLayout>
 
 <style>
-  .posts {
+  .research-list {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 14px;
+    grid-template-columns: minmax(0, 760px);
   }
 
-  .post-card {
+  .research-card {
     display: flex;
     min-height: 390px;
     padding: clamp(28px, 4vw, 46px);
     flex-direction: column;
-  }
-
-  .post-card.featured {
     background:
       radial-gradient(circle at 90% 5%, rgba(105, 230, 204, 0.11), transparent 34%),
       linear-gradient(145deg, rgba(18, 25, 25, 0.88), rgba(10, 15, 15, 0.78));
   }
 
-  .post-meta {
+  .research-meta {
     display: flex;
     justify-content: space-between;
     gap: 20px;
@@ -110,14 +90,14 @@ const schema = {
     text-transform: uppercase;
   }
 
-  .post-meta span {
+  .research-meta span {
     color: var(--accent);
   }
 
   h2 {
-    max-width: 520px;
+    max-width: 620px;
     margin: 62px 0 0;
-    font-size: clamp(1.8rem, 4vw, 3.1rem);
+    font-size: clamp(2rem, 5vw, 3.4rem);
     font-weight: 660;
     letter-spacing: -0.055em;
     line-height: 1.05;
@@ -131,8 +111,8 @@ const schema = {
     color: var(--accent);
   }
 
-  .post-card > p {
-    max-width: 560px;
+  .research-card > p {
+    max-width: 620px;
     margin: 20px 0 0;
     color: var(--text-muted);
     font-size: 0.9rem;
@@ -150,15 +130,5 @@ const schema = {
     font-size: 0.82rem;
     font-weight: 680;
     text-decoration: none;
-  }
-
-  @media (max-width: 780px) {
-    .posts {
-      grid-template-columns: 1fr;
-    }
-
-    .post-card {
-      min-height: 350px;
-    }
   }
 </style>

--- a/landing-page/src/pages/rss.xml.ts
+++ b/landing-page/src/pages/rss.xml.ts
@@ -1,4 +1,5 @@
 import { blogPosts } from '../data/blog'
+import { guides } from '../data/guides'
 import { site } from '../config'
 
 export const prerender = true
@@ -12,7 +13,16 @@ const escapeXml = (value: string) =>
     .replaceAll("'", '&apos;')
 
 export function GET() {
-  const items = blogPosts
+  const entries = [...blogPosts, ...guides].sort(
+    (left, right) =>
+      new Date(right.publishedAt).getTime() -
+      new Date(left.publishedAt).getTime()
+  )
+  const latestUpdatedAt = entries.reduce(
+    (latest, entry) => Math.max(latest, new Date(entry.updatedAt).getTime()),
+    0
+  )
+  const items = entries
     .map(
       (post) => `<item>
   <title>${escapeXml(post.title)}</title>
@@ -20,18 +30,20 @@ export function GET() {
   <guid isPermaLink="true">${site.url}${post.href}</guid>
   <description>${escapeXml(post.description)}</description>
   <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
+  <category>${escapeXml(post.category)}</category>
 </item>`
     )
     .join('\n')
 
   const body = `<?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
-  <title>Authier password manager blog</title>
-  <link>${site.url}/blog</link>
+  <title>Authier articles and guides</title>
+  <link>${site.url}/</link>
+  <atom:link href="${site.url}/rss.xml" rel="self" type="application/rss+xml" />
   <description>${escapeXml(site.description)}</description>
   <language>en</language>
-  <lastBuildDate>${new Date(blogPosts[0].updatedAt).toUTCString()}</lastBuildDate>
+  <lastBuildDate>${new Date(latestUpdatedAt).toUTCString()}</lastBuildDate>
 ${items}
 </channel>
 </rss>`

--- a/landing-page/src/pages/rss.xml.ts
+++ b/landing-page/src/pages/rss.xml.ts
@@ -1,5 +1,6 @@
 import { blogPosts } from '../data/blog'
 import { guides } from '../data/guides'
+import { researchArtifacts } from '../data/research'
 import { site } from '../config'
 
 export const prerender = true
@@ -13,7 +14,7 @@ const escapeXml = (value: string) =>
     .replaceAll("'", '&apos;')
 
 export function GET() {
-  const entries = [...blogPosts, ...guides].sort(
+  const entries = [...blogPosts, ...guides, ...researchArtifacts].sort(
     (left, right) =>
       new Date(right.publishedAt).getTime() -
       new Date(left.publishedAt).getTime()
@@ -38,7 +39,7 @@ export function GET() {
   const body = `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
-  <title>Authier articles and guides</title>
+  <title>Authier articles, guides, and research</title>
   <link>${site.url}/</link>
   <atom:link href="${site.url}/rss.xml" rel="self" type="application/rss+xml" />
   <description>${escapeXml(site.description)}</description>

--- a/research/autofill-safety/README.md
+++ b/research/autofill-safety/README.md
@@ -31,6 +31,26 @@ Run that focused adapter check from the repository root:
 pnpm --dir web-extension exec vitest run src/content-script/autofillSafetyCorpus.spec.ts
 ```
 
+Generate the public, machine-readable corpus from the typed source:
+
+```sh
+bun research/autofill-safety/exportCorpus.ts
+```
+
+The generated JSON and its SHA-256 sidecar are written to
+`landing-page/public/research/autofill-safety-corpus-v1.json` and
+`landing-page/public/research/autofill-safety-corpus-v1.sha256`. The JSON
+contains the synthetic fixtures and expected observations, not a live-browser
+result set. The sidecar uses the standard `<digest>  <filename>` format so the
+download can be verified independently.
+
+## License
+
+The corpus, runner, adapter, and generated JSON are available under
+`AGPL-3.0-or-later`; see the repository root `LICENSE` file. The generated JSON
+also carries the SPDX identifier and license URL so that the terms remain clear
+when the file is downloaded separately.
+
 ## Limits
 
 This is a synthetic DOM classifier corpus, not a live-browser suite. It does not

--- a/research/autofill-safety/README.md
+++ b/research/autofill-safety/README.md
@@ -1,0 +1,42 @@
+# Open Autofill Safety Corpus v1
+
+This directory is a small, vendor-neutral foundation for testing one narrow
+password-manager question: **which input, if any, is safe to receive a stored
+password or a time-based one-time password?**
+
+The v1 corpus uses hand-written synthetic markup. No fixture is copied from a
+vendor page. Each phase declares an exact normalized result, including target
+element IDs; “no target” is a first-class expected outcome.
+
+## Included scenarios
+
+- a password-only step in a multi-step login;
+- signup and change-password forms where a stored password must not be filled;
+- valid single-field and segmented OTP inputs;
+- recovery-code and card-security-code traps;
+- ambiguous password and OTP candidates where an adapter should abstain; and
+- a three-phase flow that replaces identifier, password, and OTP DOM nodes.
+
+The public contract is in `schema.ts`, synthetic fixtures are in `corpus.ts`,
+and `runner.ts` produces a stable report in fixture/phase ID order. An adapter
+only has to mount a phase and return the normalized observation.
+
+Authier’s adapter test lives at
+`web-extension/src/content-script/autofillSafetyCorpus.spec.ts` and reuses the
+extension’s production password-form and OTP classifiers.
+
+Run that focused adapter check from the repository root:
+
+```sh
+pnpm --dir web-extension exec vitest run src/content-script/autofillSafetyCorpus.spec.ts
+```
+
+## Limits
+
+This is a synthetic DOM classifier corpus, not a live-browser suite. It does not
+exercise extension permissions, real autofill writes, network requests, form
+submission, cross-browser behavior, cross-origin frames, closed shadow roots,
+localization heuristics, visual layout, or hostile page scripts. Passing it is
+not a security audit, a compatibility guarantee, or evidence of a measured
+false-positive rate. Those limits are also exported with the typed corpus so a
+consumer cannot mistake them for undocumented caveats.

--- a/research/autofill-safety/corpus.ts
+++ b/research/autofill-safety/corpus.ts
@@ -1,5 +1,7 @@
 import type { AutofillSafetyCorpus } from './schema'
 import {
+  OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE,
+  OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE_URL,
   OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
   OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
 } from './schema'
@@ -12,6 +14,8 @@ const standardDocument = {
 export const openAutofillSafetyCorpusV1 = {
   name: OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
   version: OPEN_AUTOFILL_SAFETY_CORPUS_VERSION,
+  license: OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE,
+  licenseUrl: OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE_URL,
   limitations: [
     'All markup is synthetic and deliberately small; it is not copied from vendor pages.',
     'The corpus does not exercise a live browser, browser-extension permissions, cross-browser behavior, network requests, form submission, or real secrets.',

--- a/research/autofill-safety/corpus.ts
+++ b/research/autofill-safety/corpus.ts
@@ -1,0 +1,368 @@
+import type { AutofillSafetyCorpus } from './schema'
+import {
+  OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
+  OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
+} from './schema'
+
+const standardDocument = {
+  language: 'en',
+  otpCodeLength: 6
+} as const
+
+export const openAutofillSafetyCorpusV1 = {
+  name: OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
+  version: OPEN_AUTOFILL_SAFETY_CORPUS_VERSION,
+  limitations: [
+    'All markup is synthetic and deliberately small; it is not copied from vendor pages.',
+    'The corpus does not exercise a live browser, browser-extension permissions, cross-browser behavior, network requests, form submission, or real secrets.',
+    'Passing the corpus is not a security audit, a compatibility guarantee, or evidence of a measured false-positive rate.',
+    'Version 1 does not cover cross-origin frames, closed shadow roots, localization heuristics, visual layout, or hostile page scripts.'
+  ],
+  fixtures: [
+    {
+      id: 'password-only-login',
+      title: 'Password-only step in a multi-step login',
+      category: 'password-only-login',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-current-password-step',
+          description:
+            'A current-password field remains a login target when the username was collected on an earlier page.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/sign-in/challenge',
+            bodyHtml: `
+              <main>
+                <h1>Welcome back</h1>
+                <form id="password-step">
+                  <input
+                    id="login-password"
+                    type="password"
+                    autocomplete="current-password"
+                  />
+                  <button type="submit">Continue</button>
+                </form>
+              </main>
+            `
+          },
+          expected: {
+            passwordKind: 'login',
+            storedPasswordTargetId: 'login-password',
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        }
+      ]
+    },
+    {
+      id: 'signup-no-fill',
+      title: 'Signup fields are not stored-password targets',
+      category: 'signup-no-fill',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-new-password-pair',
+          description:
+            'Two explicit new-password fields must not receive an existing stored password.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/join',
+            bodyHtml: `
+              <form id="signup-form">
+                <input id="signup-email" type="email" autocomplete="username" />
+                <input id="signup-password" type="password" autocomplete="new-password" />
+                <input id="signup-password-confirmation" type="password" autocomplete="new-password" />
+                <button type="submit">Create account</button>
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'signup',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        }
+      ]
+    },
+    {
+      id: 'change-password-no-fill',
+      title: 'Change-password forms are not login autofill targets',
+      category: 'change-password-no-fill',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-current-and-new-passwords',
+          description:
+            'A settings form can identify the existing-password field without authorizing automatic credential fill.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/account/security',
+            bodyHtml: `
+              <main>
+                <h1>Change password</h1>
+                <form id="change-password-form">
+                  <input id="old-password" type="password" autocomplete="current-password" />
+                  <input id="new-password" type="password" autocomplete="new-password" />
+                  <input id="new-password-confirmation" type="password" autocomplete="new-password" />
+                  <button type="submit">Update password</button>
+                </form>
+              </main>
+            `
+          },
+          expected: {
+            passwordKind: 'change-password',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        }
+      ]
+    },
+    {
+      id: 'otp-versus-code-traps',
+      title: 'OTP fields are separated from recovery and payment codes',
+      category: 'otp-versus-code-traps',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-single-otp',
+          description: 'An explicit one-time-code field is a TOTP target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/sign-in/verify',
+            bodyHtml: `
+              <form id="verification-form">
+                <label for="verification-code">Authentication code</label>
+                <input
+                  id="verification-code"
+                  name="mfa_code"
+                  type="text"
+                  inputmode="numeric"
+                  maxlength="6"
+                  autocomplete="one-time-code"
+                />
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'single',
+            otpTargetIds: ['verification-code']
+          }
+        },
+        {
+          id: '02-segmented-otp',
+          description:
+            'A corroborated six-box verification widget is an ordered TOTP target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/sign-in/verify-boxes',
+            bodyHtml: `
+              <div id="otp-code-widget">
+                <input id="otp-1" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 1" />
+                <input id="otp-2" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 2" />
+                <input id="otp-3" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 3" />
+                <input id="otp-4" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 4" />
+                <input id="otp-5" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 5" />
+                <input id="otp-6" class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 6" />
+              </div>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'segmented',
+            otpTargetIds: ['otp-1', 'otp-2', 'otp-3', 'otp-4', 'otp-5', 'otp-6']
+          }
+        },
+        {
+          id: '03-recovery-code-trap',
+          description:
+            'A recovery-code field stays excluded even when misleading markup advertises one-time-code.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/account/recovery',
+            bodyHtml: `
+              <form id="recovery-form">
+                <label for="recovery-code">Recovery code</label>
+                <input
+                  id="recovery-code"
+                  name="recovery_code"
+                  type="text"
+                  inputmode="numeric"
+                  maxlength="10"
+                  autocomplete="one-time-code"
+                />
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        },
+        {
+          id: '04-card-security-code-trap',
+          description:
+            'A card verification value is payment data, not a one-time authentication code.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/checkout',
+            bodyHtml: `
+              <form id="payment-form">
+                <label for="card-security-code">Card security code</label>
+                <input
+                  id="card-security-code"
+                  name="cvv"
+                  type="text"
+                  inputmode="numeric"
+                  maxlength="3"
+                  autocomplete="cc-csc"
+                />
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        }
+      ]
+    },
+    {
+      id: 'ambiguity',
+      title: 'Ambiguous targets cause abstention',
+      category: 'ambiguity',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-unannotated-password-form',
+          description:
+            'An unannotated password form without decisive context is not treated as a login target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/access',
+            bodyHtml: `
+              <form id="ambiguous-password-form">
+                <input id="account-alias" type="text" name="account-alias" />
+                <input id="ambiguous-password" type="password" />
+                <button type="submit">Proceed</button>
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'unknown',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        },
+        {
+          id: '02-two-equally-plausible-otp-fields',
+          description:
+            'Two equally scored OTP candidates are not resolved by DOM order.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/verify-choice',
+            bodyHtml: `
+              <form id="ambiguous-code-form">
+                <input id="verification-left" name="mfa_code_left" type="text" inputmode="numeric" maxlength="6" />
+                <input id="verification-right" name="mfa_code_right" type="text" inputmode="numeric" maxlength="6" />
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        }
+      ]
+    },
+    {
+      id: 'dynamic-replacement',
+      title: 'Multi-step authentication replaces its inputs',
+      category: 'dynamic-replacement',
+      provenance: 'synthetic',
+      phases: [
+        {
+          id: '01-identifier-step',
+          description: 'The first DOM has an identifier and no secret target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/session/identifier',
+            bodyHtml: `
+              <form id="session-step">
+                <input id="session-identifier" type="email" autocomplete="username" />
+                <button type="submit">Continue</button>
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        },
+        {
+          id: '02-password-step',
+          description:
+            'After replacement, the newly queried current-password node is the login target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/session/password',
+            bodyHtml: `
+              <form id="session-step">
+                <input id="session-password" type="password" autocomplete="current-password" />
+                <button type="submit">Continue</button>
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'login',
+            storedPasswordTargetId: 'session-password',
+            otpKind: 'none',
+            otpTargetIds: []
+          }
+        },
+        {
+          id: '03-otp-step',
+          description:
+            'A second replacement removes the password target and introduces a fresh OTP target.',
+          document: {
+            ...standardDocument,
+            url: 'https://synthetic.invalid/session/otp',
+            bodyHtml: `
+              <form id="session-step">
+                <input
+                  id="session-otp"
+                  name="otp_code"
+                  type="text"
+                  inputmode="numeric"
+                  maxlength="6"
+                  autocomplete="one-time-code"
+                />
+                <button type="submit">Verify</button>
+              </form>
+            `
+          },
+          expected: {
+            passwordKind: 'none',
+            storedPasswordTargetId: null,
+            otpKind: 'single',
+            otpTargetIds: ['session-otp']
+          }
+        }
+      ]
+    }
+  ]
+} as const satisfies AutofillSafetyCorpus

--- a/research/autofill-safety/exportCorpus.ts
+++ b/research/autofill-safety/exportCorpus.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { openAutofillSafetyCorpusV1 } from './corpus'
+
+const outputUrl = new URL(
+  '../../landing-page/public/research/autofill-safety-corpus-v1.json',
+  import.meta.url
+)
+const checksumOutputUrl = new URL(
+  '../../landing-page/public/research/autofill-safety-corpus-v1.sha256',
+  import.meta.url
+)
+const outputPath = fileURLToPath(outputUrl)
+const checksumOutputPath = fileURLToPath(checksumOutputUrl)
+const serializedCorpus = `${JSON.stringify(openAutofillSafetyCorpusV1, null, 2)}\n`
+const checksum = createHash('sha256').update(serializedCorpus).digest('hex')
+
+await mkdir(dirname(outputPath), { recursive: true })
+await writeFile(outputPath, serializedCorpus, 'utf8')
+await writeFile(
+  checksumOutputPath,
+  `${checksum}  autofill-safety-corpus-v1.json\n`,
+  'utf8'
+)
+
+console.log(`${outputPath}\n${checksumOutputPath}`)

--- a/research/autofill-safety/index.ts
+++ b/research/autofill-safety/index.ts
@@ -1,0 +1,21 @@
+export { openAutofillSafetyCorpusV1 } from './corpus'
+export { runAutofillSafetyCorpus } from './runner'
+export type {
+  AutofillSafetyAdapter,
+  AutofillSafetyPhaseResult,
+  AutofillSafetyRunReport
+} from './runner'
+export {
+  OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
+  OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
+} from './schema'
+export type {
+  AutofillSafetyCategory,
+  AutofillSafetyCorpus,
+  AutofillSafetyDocument,
+  AutofillSafetyFixture,
+  AutofillSafetyObservation,
+  AutofillSafetyOtpKind,
+  AutofillSafetyPasswordKind,
+  AutofillSafetyPhase
+} from './schema'

--- a/research/autofill-safety/index.ts
+++ b/research/autofill-safety/index.ts
@@ -6,6 +6,8 @@ export type {
   AutofillSafetyRunReport
 } from './runner'
 export {
+  OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE,
+  OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE_URL,
   OPEN_AUTOFILL_SAFETY_CORPUS_NAME,
   OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
 } from './schema'

--- a/research/autofill-safety/runner.ts
+++ b/research/autofill-safety/runner.ts
@@ -1,0 +1,149 @@
+import type {
+  AutofillSafetyCorpus,
+  AutofillSafetyFixture,
+  AutofillSafetyObservation,
+  AutofillSafetyPhase
+} from './schema'
+
+export interface AutofillSafetyAdapter {
+  readonly name: string
+  mountDocument: (phase: AutofillSafetyPhase) => void
+  inspectDocument: (phase: AutofillSafetyPhase) => AutofillSafetyObservation
+}
+
+export interface AutofillSafetyPhaseResult {
+  readonly fixtureId: string
+  readonly phaseId: string
+  readonly passed: boolean
+  readonly mismatches: readonly string[]
+  readonly expected: AutofillSafetyObservation
+  readonly actual: AutofillSafetyObservation
+}
+
+export interface AutofillSafetyRunReport {
+  readonly corpusName: string
+  readonly corpusVersion: string
+  readonly adapterName: string
+  readonly passed: boolean
+  readonly fixtureCount: number
+  readonly phaseCount: number
+  readonly phaseResults: readonly AutofillSafetyPhaseResult[]
+}
+
+const compareText = (left: string, right: string): number => {
+  if (left < right) {
+    return -1
+  }
+  if (left > right) {
+    return 1
+  }
+  return 0
+}
+
+const sortedFixtures = (
+  fixtures: readonly AutofillSafetyFixture[]
+): AutofillSafetyFixture[] =>
+  [...fixtures].sort((left, right) => compareText(left.id, right.id))
+
+const sortedPhases = (
+  phases: readonly AutofillSafetyPhase[]
+): AutofillSafetyPhase[] =>
+  [...phases].sort((left, right) => compareText(left.id, right.id))
+
+const idsMatch = (left: readonly string[], right: readonly string[]) =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index])
+
+const compareObservation = (
+  expected: AutofillSafetyObservation,
+  actual: AutofillSafetyObservation
+): string[] => {
+  const mismatches: string[] = []
+
+  if (actual.passwordKind !== expected.passwordKind) {
+    mismatches.push(
+      `passwordKind: expected ${expected.passwordKind}, received ${actual.passwordKind}`
+    )
+  }
+
+  if (actual.storedPasswordTargetId !== expected.storedPasswordTargetId) {
+    mismatches.push(
+      `storedPasswordTargetId: expected ${String(expected.storedPasswordTargetId)}, received ${String(actual.storedPasswordTargetId)}`
+    )
+  }
+
+  if (actual.otpKind !== expected.otpKind) {
+    mismatches.push(
+      `otpKind: expected ${expected.otpKind}, received ${actual.otpKind}`
+    )
+  }
+
+  if (!idsMatch(actual.otpTargetIds, expected.otpTargetIds)) {
+    mismatches.push(
+      `otpTargetIds: expected [${expected.otpTargetIds.join(', ')}], received [${actual.otpTargetIds.join(', ')}]`
+    )
+  }
+
+  return mismatches
+}
+
+const assertUniqueIds = (corpus: AutofillSafetyCorpus): void => {
+  const fixtureIds = new Set<string>()
+  const phaseIds = new Set<string>()
+
+  for (const fixture of corpus.fixtures) {
+    if (fixtureIds.has(fixture.id)) {
+      throw new Error(`Duplicate fixture id: ${fixture.id}`)
+    }
+    fixtureIds.add(fixture.id)
+
+    for (const phase of fixture.phases) {
+      const qualifiedPhaseId = `${fixture.id}/${phase.id}`
+      if (phaseIds.has(qualifiedPhaseId)) {
+        throw new Error(`Duplicate phase id: ${qualifiedPhaseId}`)
+      }
+      phaseIds.add(qualifiedPhaseId)
+    }
+  }
+}
+
+/**
+ * Runs fixtures in stable identifier order and emits no timestamps, randomness,
+ * or environment-dependent metadata, so identical observations yield an
+ * identical report.
+ */
+export const runAutofillSafetyCorpus = (
+  corpus: AutofillSafetyCorpus,
+  adapter: AutofillSafetyAdapter
+): AutofillSafetyRunReport => {
+  assertUniqueIds(corpus)
+
+  const phaseResults: AutofillSafetyPhaseResult[] = []
+
+  for (const fixture of sortedFixtures(corpus.fixtures)) {
+    for (const phase of sortedPhases(fixture.phases)) {
+      adapter.mountDocument(phase)
+      const actual = adapter.inspectDocument(phase)
+      const mismatches = compareObservation(phase.expected, actual)
+
+      phaseResults.push({
+        fixtureId: fixture.id,
+        phaseId: phase.id,
+        passed: mismatches.length === 0,
+        mismatches,
+        expected: phase.expected,
+        actual
+      })
+    }
+  }
+
+  return {
+    corpusName: corpus.name,
+    corpusVersion: corpus.version,
+    adapterName: adapter.name,
+    passed: phaseResults.every((result) => result.passed),
+    fixtureCount: corpus.fixtures.length,
+    phaseCount: phaseResults.length,
+    phaseResults
+  }
+}

--- a/research/autofill-safety/schema.ts
+++ b/research/autofill-safety/schema.ts
@@ -3,6 +3,11 @@ export const OPEN_AUTOFILL_SAFETY_CORPUS_NAME =
 
 export const OPEN_AUTOFILL_SAFETY_CORPUS_VERSION = '1.0.0' as const
 
+export const OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE = 'AGPL-3.0-or-later' as const
+
+export const OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE_URL =
+  'https://spdx.org/licenses/AGPL-3.0-or-later.html' as const
+
 export type AutofillSafetyCategory =
   | 'password-only-login'
   | 'signup-no-fill'
@@ -55,6 +60,8 @@ export interface AutofillSafetyFixture {
 export interface AutofillSafetyCorpus {
   readonly name: typeof OPEN_AUTOFILL_SAFETY_CORPUS_NAME
   readonly version: typeof OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
+  readonly license: typeof OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE
+  readonly licenseUrl: typeof OPEN_AUTOFILL_SAFETY_CORPUS_LICENSE_URL
   readonly limitations: readonly string[]
   readonly fixtures: readonly AutofillSafetyFixture[]
 }

--- a/research/autofill-safety/schema.ts
+++ b/research/autofill-safety/schema.ts
@@ -1,0 +1,60 @@
+export const OPEN_AUTOFILL_SAFETY_CORPUS_NAME =
+  'Open Autofill Safety Corpus' as const
+
+export const OPEN_AUTOFILL_SAFETY_CORPUS_VERSION = '1.0.0' as const
+
+export type AutofillSafetyCategory =
+  | 'password-only-login'
+  | 'signup-no-fill'
+  | 'change-password-no-fill'
+  | 'otp-versus-code-traps'
+  | 'ambiguity'
+  | 'dynamic-replacement'
+
+export type AutofillSafetyPasswordKind =
+  | 'login'
+  | 'signup'
+  | 'change-password'
+  | 'unknown'
+  | 'none'
+
+export type AutofillSafetyOtpKind = 'single' | 'segmented' | 'none'
+
+export interface AutofillSafetyDocument {
+  readonly url: string
+  readonly language: string | null
+  readonly bodyHtml: string
+  /** The length of the synthetic TOTP value an adapter should look for. */
+  readonly otpCodeLength: number
+}
+
+export interface AutofillSafetyObservation {
+  readonly passwordKind: AutofillSafetyPasswordKind
+  /** Null means a stored password must not be written in this phase. */
+  readonly storedPasswordTargetId: string | null
+  readonly otpKind: AutofillSafetyOtpKind
+  /** Empty means a TOTP value must not be written in this phase. */
+  readonly otpTargetIds: readonly string[]
+}
+
+export interface AutofillSafetyPhase {
+  readonly id: string
+  readonly description: string
+  readonly document: AutofillSafetyDocument
+  readonly expected: AutofillSafetyObservation
+}
+
+export interface AutofillSafetyFixture {
+  readonly id: string
+  readonly title: string
+  readonly category: AutofillSafetyCategory
+  readonly provenance: 'synthetic'
+  readonly phases: readonly AutofillSafetyPhase[]
+}
+
+export interface AutofillSafetyCorpus {
+  readonly name: typeof OPEN_AUTOFILL_SAFETY_CORPUS_NAME
+  readonly version: typeof OPEN_AUTOFILL_SAFETY_CORPUS_VERSION
+  readonly limitations: readonly string[]
+  readonly fixtures: readonly AutofillSafetyFixture[]
+}

--- a/web-extension/src/content-script/autofill.spec.ts
+++ b/web-extension/src/content-script/autofill.spec.ts
@@ -282,6 +282,59 @@ describe('autofill on a login page', () => {
     expect(inputById('q').value).toBe('')
     expect(inputById('user').value).toBe(STORED_USERNAME)
   })
+
+  it('fills only the classifier-selected password target', async () => {
+    setPage(
+      `<form>
+        <input id="user" type="text" autocomplete="username" />
+        <input id="decoy" type="password" autocomplete="off" />
+        <input id="pw" type="password" autocomplete="current-password" />
+        <button type="submit">Sign in</button>
+      </form>`,
+      { url: '/login' }
+    )
+
+    await runAutofill()
+
+    expect(inputById('decoy').value).toBe('')
+    expect(inputById('pw').value).toBe(STORED_PASSWORD)
+  })
+
+  it('falls back to the selected target when a learned path points at a decoy', async () => {
+    setPage(
+      `<form>
+        <input id="user" type="text" autocomplete="username" />
+        <input id="decoy" type="password" autocomplete="off" />
+        <input id="pw" type="password" autocomplete="current-password" />
+        <button type="submit">Sign in</button>
+      </form>`,
+      { url: '/login' }
+    )
+
+    await runAutofill(
+      initState([
+        {
+          domPath: '#user',
+          domOrdinal: 0,
+          kind: 'USERNAME',
+          url: 'https://example.com/login',
+          host: 'example.com',
+          createdAt: new Date().toString()
+        },
+        {
+          domPath: '#decoy',
+          domOrdinal: 0,
+          kind: 'PASSWORD',
+          url: 'https://example.com/login',
+          host: 'example.com',
+          createdAt: new Date().toString()
+        }
+      ] as unknown as IInitStateRes['webInputs'])
+    )
+
+    expect(inputById('decoy').value).toBe('')
+    expect(inputById('pw').value).toBe(STORED_PASSWORD)
+  })
 })
 
 describe('autofill on a change-password page', () => {

--- a/web-extension/src/content-script/autofill.ts
+++ b/web-extension/src/content-script/autofill.ts
@@ -39,6 +39,10 @@ import {
   PasswordFormClassification,
   PasswordFormKind
 } from './classifyPasswordForm'
+import {
+  isStoredPasswordAutofillTarget,
+  selectStoredPasswordAutofillTarget
+} from './storedPasswordAutofillPolicy'
 import { renderPasswordGenerator } from './renderPasswordGenerator'
 import {
   findSegmentedOtpInputs,
@@ -683,6 +687,8 @@ export const autofill = (initState: IInitStateRes) => {
      * silent fill.
      */
     const classification = classifyPageForAutofill(usefulInputs, body)
+    const storedPasswordTarget =
+      selectStoredPasswordAutofillTarget(classification)
 
     // arm this before any of the bail-outs below - even on a page we refuse to
     // autofill, the next form to appear may be a login form
@@ -714,17 +720,17 @@ export const autofill = (initState: IInitStateRes) => {
       if (inputEl) {
         // log('webInputGql was found')
 
-        foundInputsCount++
         log(`autofilled by domPath ${webInputGql.domPath}`)
         if (
           webInputGql.kind === WebInputType.PASSWORD &&
           firstLoginCred &&
           inputEl.type === 'password' && // we don't want to autofill password to any other type of input
-          // DOM paths are matched loosely by URL, so a path learned on the login
-          // page also gets served on the settings page - never let it land in a
-          // field meant to receive a brand new password
-          classification.newPasswordInputs.includes(inputEl) === false
+          // DOM paths are matched loosely by URL. Reuse the same production
+          // policy as classifier-based fill so a learned path cannot authorize
+          // a different password field.
+          isStoredPasswordAutofillTarget(classification, inputEl)
         ) {
+          foundInputsCount++
           const el = fillStringIntoInput({
             inputEl,
             loginCredential: firstLoginCred.loginCredentials,
@@ -740,6 +746,7 @@ export const autofill = (initState: IInitStateRes) => {
           ].includes(webInputGql.kind) &&
           firstLoginCred
         ) {
+          foundInputsCount++
           const el = autofillValueIntoInput(
             inputEl,
             firstLoginCred.loginCredentials.username
@@ -750,6 +757,7 @@ export const autofill = (initState: IInitStateRes) => {
             log('no totp secret')
             return
           }
+          foundInputsCount++
           const totpCode = safeGenerateTotpCode(totpSecret)
           if (!totpCode) {
             return
@@ -768,10 +776,17 @@ export const autofill = (initState: IInitStateRes) => {
     }
 
     //NOTE: Guess web inputs, if we have credentials without DOM PATHS
+    const mappedPasswordWasFilled =
+      storedPasswordTarget !== null &&
+      filledElements.has(storedPasswordTarget) &&
+      storedPasswordTarget.value !== ''
+    const shouldSearchForCredentialInputs =
+      foundInputsCount === 0 ||
+      (storedPasswordTarget !== null && !mappedPasswordWasFilled)
+
     if (
-      foundInputsCount === 0 &&
+      shouldSearchForCredentialInputs &&
       secretsForHost.loginCredentials.length > 0
-      // filledElements.length === 0
     ) {
       const autofillResult = await searchInputsAndAutofill(body, classification)
       if (autofillResult) {
@@ -967,6 +982,8 @@ export const autofill = (initState: IInitStateRes) => {
       formClassification: PasswordFormClassification
     ) {
       const newWebInputs: WebInputsArrayClientSide = []
+      const storedPasswordTarget =
+        selectStoredPasswordAutofillTarget(formClassification)
       // only look inside the credential form - a flat scan of the whole document
       // is how a site-wide search box ends up being treated as the username field
       const inputElsArray = (
@@ -975,7 +992,7 @@ export const autofill = (initState: IInitStateRes) => {
       log('inputElsArray', inputElsArray)
 
       if (inputElsArray.length === 1) {
-        if (inputElsArray[0].type === 'password') {
+        if (inputElsArray[0] === storedPasswordTarget) {
           // this branch handles multi step google login pages specifically. We might add more cases in the future
           const visibleText = getAllVisibleTextOnDocumentBody()
 
@@ -1016,6 +1033,10 @@ export const autofill = (initState: IInitStateRes) => {
         for (let index = 0; index < inputElsArray.length; index++) {
           const input = inputElsArray[index]
           if (input.type === 'password') {
+            if (input !== storedPasswordTarget) {
+              continue
+            }
+
             //Save password input, if we have more credentials with no DOM PATH
             if (
               webInputs.length === 0 &&

--- a/web-extension/src/content-script/autofillSafetyCorpus.spec.ts
+++ b/web-extension/src/content-script/autofillSafetyCorpus.spec.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import type {
+  AutofillSafetyAdapter,
+  AutofillSafetyObservation,
+  AutofillSafetyPasswordKind,
+  AutofillSafetyPhase
+} from '../../../research/autofill-safety'
+import {
+  openAutofillSafetyCorpusV1,
+  runAutofillSafetyCorpus
+} from '../../../research/autofill-safety'
+import {
+  classifyPasswordForm,
+  PasswordFormKind,
+  resetLanguageCache
+} from './classifyPasswordForm'
+import { findSegmentedOtpInputs, findSingleOtpInput } from './findOtpInputs'
+
+const originalLocation = { ...window.location }
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 10
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => 10
+  })
+})
+
+afterAll(() => {
+  Object.assign(window.location, originalLocation)
+})
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  document.documentElement.setAttribute('lang', 'en')
+  resetLanguageCache()
+})
+
+const setUrl = (url: string): void => {
+  const parsed = new URL(url)
+  Object.assign(window.location, {
+    href: parsed.href,
+    pathname: parsed.pathname,
+    search: parsed.search,
+    host: parsed.host,
+    hostname: parsed.hostname,
+    origin: parsed.origin,
+    protocol: parsed.protocol
+  })
+}
+
+const mountDocument = (phase: AutofillSafetyPhase): void => {
+  setUrl(phase.document.url)
+
+  if (phase.document.language === null) {
+    document.documentElement.removeAttribute('lang')
+  } else {
+    document.documentElement.setAttribute('lang', phase.document.language)
+  }
+
+  document.body.innerHTML = phase.document.bodyHtml
+  resetLanguageCache()
+}
+
+const mapPasswordKind = (
+  kind: PasswordFormKind
+): AutofillSafetyPasswordKind => {
+  switch (kind) {
+    case PasswordFormKind.LOGIN:
+      return 'login'
+    case PasswordFormKind.SIGNUP:
+      return 'signup'
+    case PasswordFormKind.CHANGE_PASSWORD:
+      return 'change-password'
+    case PasswordFormKind.UNKNOWN:
+      return 'unknown'
+  }
+}
+
+const inspectDocument = (
+  phase: AutofillSafetyPhase
+): AutofillSafetyObservation => {
+  const inputs = Array.from(
+    document.querySelectorAll<HTMLInputElement>('input')
+  )
+  const passwordInput = inputs.find((input) => input.type === 'password')
+
+  let passwordKind: AutofillSafetyPasswordKind = 'none'
+  let storedPasswordTargetId: string | null = null
+
+  if (passwordInput) {
+    const classification = classifyPasswordForm(passwordInput)
+    passwordKind = mapPasswordKind(classification.kind)
+
+    if (classification.kind === PasswordFormKind.LOGIN) {
+      storedPasswordTargetId = classification.currentPasswordInput?.id ?? null
+    }
+  }
+
+  const segmentedOtp = findSegmentedOtpInputs(
+    inputs,
+    phase.document.otpCodeLength
+  )
+  if (segmentedOtp) {
+    return {
+      passwordKind,
+      storedPasswordTargetId,
+      otpKind: 'segmented',
+      otpTargetIds: segmentedOtp.inputs.map((input) => input.id)
+    }
+  }
+
+  const singleOtp = findSingleOtpInput(inputs, phase.document.otpCodeLength)
+  if (singleOtp) {
+    return {
+      passwordKind,
+      storedPasswordTargetId,
+      otpKind: 'single',
+      otpTargetIds: [singleOtp.input.id]
+    }
+  }
+
+  return {
+    passwordKind,
+    storedPasswordTargetId,
+    otpKind: 'none',
+    otpTargetIds: []
+  }
+}
+
+const authierAdapter: AutofillSafetyAdapter = {
+  name: 'Authier production classifiers',
+  mountDocument,
+  inspectDocument
+}
+
+describe('Open Autofill Safety Corpus v1 adapter', () => {
+  it('matches every synthetic safety expectation', () => {
+    const report = runAutofillSafetyCorpus(
+      openAutofillSafetyCorpusV1,
+      authierAdapter
+    )
+
+    expect(report.fixtureCount).toBe(6)
+    expect(report.phaseCount).toBe(12)
+    expect(report.phaseResults.filter((result) => !result.passed)).toEqual([])
+    expect(report.passed).toBe(true)
+  })
+
+  it('produces the same report on repeated runs', () => {
+    const first = runAutofillSafetyCorpus(
+      openAutofillSafetyCorpusV1,
+      authierAdapter
+    )
+    const second = runAutofillSafetyCorpus(
+      openAutofillSafetyCorpusV1,
+      authierAdapter
+    )
+
+    expect(second).toEqual(first)
+  })
+})

--- a/web-extension/src/content-script/autofillSafetyCorpus.spec.ts
+++ b/web-extension/src/content-script/autofillSafetyCorpus.spec.ts
@@ -15,6 +15,7 @@ import {
   resetLanguageCache
 } from './classifyPasswordForm'
 import { findSegmentedOtpInputs, findSingleOtpInput } from './findOtpInputs'
+import { selectStoredPasswordAutofillTarget } from './storedPasswordAutofillPolicy'
 
 const originalLocation = { ...window.location }
 
@@ -94,10 +95,8 @@ const inspectDocument = (
   if (passwordInput) {
     const classification = classifyPasswordForm(passwordInput)
     passwordKind = mapPasswordKind(classification.kind)
-
-    if (classification.kind === PasswordFormKind.LOGIN) {
-      storedPasswordTargetId = classification.currentPasswordInput?.id ?? null
-    }
+    storedPasswordTargetId =
+      selectStoredPasswordAutofillTarget(classification)?.id ?? null
   }
 
   const segmentedOtp = findSegmentedOtpInputs(
@@ -132,7 +131,7 @@ const inspectDocument = (
 }
 
 const authierAdapter: AutofillSafetyAdapter = {
-  name: 'Authier production classifiers',
+  name: 'Authier production classifiers and stored-password target policy',
   mountDocument,
   inspectDocument
 }

--- a/web-extension/src/content-script/getAllInputsIncludingShadowDom.spec.ts
+++ b/web-extension/src/content-script/getAllInputsIncludingShadowDom.spec.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mainWorldAutofillFunction } from './getAllInputsIncludingShadowDom'
+
+const USERNAME = 'jiri@example.com'
+const PASSWORD = 'stored-password-42'
+
+const credentials = () => [
+  {
+    username: USERNAME,
+    password: PASSWORD,
+    lastUsedAt: '2026-09-01T00:00:00.000Z'
+  }
+]
+
+const inputById = (id: string): HTMLInputElement => {
+  const input = document.getElementById(id)
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Missing input: ${id}`)
+  }
+  return input
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 10
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => 10
+  })
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    top: 0,
+    right: 10,
+    bottom: 10,
+    left: 0,
+    toJSON: () => ({})
+  })
+})
+
+describe('main-world autofill fallback', () => {
+  it('fills an explicit username and current-password login', () => {
+    document.body.innerHTML = `<form>
+      <input id="user" autocomplete="username" />
+      <input id="password" type="password" autocomplete="current-password" />
+    </form>`
+
+    mainWorldAutofillFunction(credentials())
+
+    expect(inputById('user').value).toBe(USERNAME)
+    expect(inputById('password').value).toBe(PASSWORD)
+  })
+
+  it('fills only the explicit current-password field when a decoy is present', () => {
+    document.body.innerHTML = `<form>
+      <input id="user" autocomplete="username" />
+      <input id="decoy" type="password" autocomplete="off" />
+      <input id="password" type="password" autocomplete="current-password" />
+    </form>`
+
+    mainWorldAutofillFunction(credentials())
+
+    expect(inputById('decoy').value).toBe('')
+    expect(inputById('password').value).toBe(PASSWORD)
+  })
+
+  it('abstains from signup fields', () => {
+    document.body.innerHTML = `<form>
+      <input id="user" autocomplete="username" />
+      <input id="password" type="password" autocomplete="new-password" />
+      <input id="confirmation" type="password" autocomplete="new-password" />
+    </form>`
+
+    expect(mainWorldAutofillFunction(credentials())).toEqual([])
+    expect(inputById('user').value).toBe('')
+    expect(inputById('password').value).toBe('')
+    expect(inputById('confirmation').value).toBe('')
+  })
+
+  it('abstains from change-password forms', () => {
+    document.body.innerHTML = `<form>
+      <input id="old-password" type="password" autocomplete="current-password" />
+      <input id="new-password" type="password" autocomplete="new-password" />
+    </form>`
+
+    expect(mainWorldAutofillFunction(credentials())).toEqual([])
+    expect(inputById('old-password').value).toBe('')
+    expect(inputById('new-password').value).toBe('')
+  })
+
+  it('abstains when a new-password field is hidden from fill candidates', () => {
+    document.body.innerHTML = `<form>
+      <input id="old-password" type="password" autocomplete="current-password" />
+      <input id="new-password" type="password" autocomplete="new-password" />
+    </form>`
+    Object.defineProperty(inputById('new-password'), 'offsetWidth', {
+      configurable: true,
+      value: 0
+    })
+
+    expect(mainWorldAutofillFunction(credentials())).toEqual([])
+    expect(inputById('old-password').value).toBe('')
+    expect(inputById('new-password').value).toBe('')
+  })
+
+  it('abstains when a new-password field already has a value', () => {
+    document.body.innerHTML = `<form>
+      <input id="old-password" type="password" autocomplete="current-password" />
+      <input id="new-password" type="password" autocomplete="new-password" value="existing-draft" />
+    </form>`
+
+    expect(mainWorldAutofillFunction(credentials())).toEqual([])
+    expect(inputById('old-password').value).toBe('')
+    expect(inputById('new-password').value).toBe('existing-draft')
+  })
+
+  it('abstains from ambiguous unannotated password fields', () => {
+    document.body.innerHTML = `<form>
+      <input id="first" type="password" />
+      <input id="second" type="password" />
+    </form>`
+
+    expect(mainWorldAutofillFunction(credentials())).toEqual([])
+    expect(inputById('first').value).toBe('')
+    expect(inputById('second').value).toBe('')
+  })
+
+  it.each([
+    ['the hidden attribute', 'hidden', ''],
+    ['display none', 'style', 'display: none'],
+    ['hidden visibility', 'style', 'visibility: hidden'],
+    ['collapsed visibility', 'style', 'visibility: collapse'],
+    ['zero opacity', 'style', 'opacity: 0']
+  ])(
+    'abstains from a current-password input concealed by %s',
+    (_, name, value) => {
+      document.body.innerHTML = `<form>
+      <input id="password" type="password" autocomplete="current-password" />
+    </form>`
+      inputById('password').setAttribute(name, value)
+
+      expect(mainWorldAutofillFunction(credentials())).toEqual([])
+      expect(inputById('password').value).toBe('')
+    }
+  )
+
+  it.each(['disabled', 'readonly'])(
+    'abstains from an ineligible %s current-password input',
+    (attribute) => {
+      document.body.innerHTML = `<form>
+        <input id="password" type="password" autocomplete="current-password" ${attribute} />
+      </form>`
+
+      expect(mainWorldAutofillFunction(credentials())).toEqual([])
+      expect(inputById('password').value).toBe('')
+    }
+  )
+
+  it('still fills an explicit username-only login step', () => {
+    document.body.innerHTML = `<form>
+      <input id="user" autocomplete="username" />
+    </form>`
+
+    mainWorldAutofillFunction(credentials())
+
+    expect(inputById('user').value).toBe(USERNAME)
+  })
+
+  it('runs from its serialized body without module closures', () => {
+    document.body.innerHTML = `<form>
+      <input id="user" autocomplete="username" />
+      <input id="password" type="password" autocomplete="current-password" />
+    </form>`
+    const serializedFunction = mainWorldAutofillFunction.toString()
+    const executeSerialized: typeof mainWorldAutofillFunction = window.eval(
+      `(${serializedFunction})`
+    )
+
+    executeSerialized(credentials())
+
+    expect(serializedFunction).not.toContain('WebInputType')
+    expect(inputById('user').value).toBe(USERNAME)
+    expect(inputById('password').value).toBe(PASSWORD)
+  })
+})

--- a/web-extension/src/content-script/getAllInputsIncludingShadowDom.ts
+++ b/web-extension/src/content-script/getAllInputsIncludingShadowDom.ts
@@ -1,5 +1,3 @@
-import { WebInputType } from '../../../shared/generated/graphqlBaseTypes'
-
 // this entire file is just for testing in a browser console
 
 const uselessInputTypes = [
@@ -93,7 +91,13 @@ export function mainWorldAutofillFunction(
 
   function isHidden(el) {
     const style = window.getComputedStyle(el)
-    return style.display === 'none'
+    return (
+      el.hidden ||
+      style.display === 'none' ||
+      style.visibility === 'hidden' ||
+      style.visibility === 'collapse' ||
+      style.opacity === '0'
+    )
   }
 
   function imitateKeyInput(el: HTMLInputElement, input: string) {
@@ -226,10 +230,41 @@ export function mainWorldAutofillFunction(
     return inputElsArray
   }
 
+  const allInputs = getAllInputsIncludingShadowDom(document.body)
   const inputs = filterUselessInputs(document.body)
 
+  // This function is serialized into the page's MAIN world, so it cannot call
+  // the imported content-script classifier. Keep its fallback deliberately
+  // narrower: only an explicit, unambiguous current-password field is eligible,
+  // and the presence of any new-password field makes the whole form ineligible.
+  const passwordInputs = allInputs.filter((input) => input.type === 'password')
+  const hasNewPasswordInput = passwordInputs.some((input) =>
+    input.autocomplete.toLowerCase().split(/\s+/).includes('new-password')
+  )
+  const currentPasswordInputs = passwordInputs.filter((input) =>
+    input.autocomplete.toLowerCase().split(/\s+/).includes('current-password')
+  )
+  let storedPasswordTarget: HTMLInputElement | null = null
+
+  const currentPasswordInput = currentPasswordInputs[0]
+  if (
+    !hasNewPasswordInput &&
+    currentPasswordInputs.length === 1 &&
+    inputs.includes(currentPasswordInput) &&
+    !currentPasswordInput.disabled &&
+    !currentPasswordInput.readOnly &&
+    !isHidden(currentPasswordInput) &&
+    isElementInViewport(currentPasswordInput)
+  ) {
+    storedPasswordTarget = currentPasswordInput
+  }
+
+  if (passwordInputs.length > 0 && storedPasswordTarget === null) {
+    return []
+  }
+
   const autofilledInputs: Array<{
-    webInputType: WebInputType | null
+    webInputType: 'USERNAME' | 'PASSWORD' | null
     username: string | null
   }> = []
 
@@ -253,16 +288,16 @@ export function mainWorldAutofillFunction(
         recentlyUsedLogin.username
       )
       autofilledInputs.push({
-        webInputType: WebInputType.USERNAME,
+        webInputType: 'USERNAME',
         username: recentlyUsedLogin.username
       })
-    } else if (input.type === 'password') {
+    } else if (input === storedPasswordTarget) {
       const autofilledElPassword = autofillValueIntoInput(
         input,
         recentlyUsedLogin.password
       )
       autofilledInputs.push({
-        webInputType: WebInputType.PASSWORD,
+        webInputType: 'PASSWORD',
         username: recentlyUsedLogin.username
       })
     }

--- a/web-extension/src/content-script/storedPasswordAutofillPolicy.ts
+++ b/web-extension/src/content-script/storedPasswordAutofillPolicy.ts
@@ -1,0 +1,21 @@
+import {
+  type PasswordFormClassification,
+  PasswordFormKind
+} from './classifyPasswordForm'
+
+/**
+ * Returns the only field that production autofill may receive a stored
+ * password. Signup, password-change, and unknown forms deliberately return no
+ * target even when they contain a current-password-shaped input.
+ */
+export const selectStoredPasswordAutofillTarget = (
+  classification: PasswordFormClassification
+): HTMLInputElement | null =>
+  classification.kind === PasswordFormKind.LOGIN
+    ? classification.currentPasswordInput
+    : null
+
+export const isStoredPasswordAutofillTarget = (
+  classification: PasswordFormClassification,
+  candidate: HTMLInputElement
+): boolean => selectStoredPasswordAutofillTarget(classification) === candidate


### PR DESCRIPTION
## Summary

- add Open Autofill Safety Corpus v1 as typed synthetic fixtures, a deterministic runner, and an adapter over Authier's production classifiers
- publish a canonical research page, JSON artifact, SHA-256 sidecar, structured data, RSS/navigation discovery, and explicit evidence limitations
- make stored-password autofill use one shared target policy, including the serialized main-world fallback, with regression coverage for decoys, signup, password-change, ambiguity, and hidden inputs
- correct the public security contact address and replace the dead OpenPGP lookup URL

The corpus deliberately covers jsdom classification only. It is not presented as a live-browser benchmark, compatibility result, measured false-positive study, vulnerability report, security audit, or overall product-security claim.

## Verification

- `pnpm --dir web-extension test` — 20 files passed, 1 skipped; 154 tests passed
- `pnpm tsc` — all four TypeScript package tasks passed
- `pnpm --dir landing-page build` — 19 pages; zero Astro errors, warnings, or hints
- `pnpm --dir landing-page check:seo` — 568 internal links and 42 structured-data blocks passed
- exporter run twice with byte-identical output
- `sha256sum -c autofill-safety-corpus-v1.sha256` passed after formatting and commit hooks
- focused formatting and `git diff --check` passed

## Review notes

- generated corpus JSON is intentionally ignored by oxfmt so commit hooks cannot rewrite it after the sidecar hash is calculated
- the page computes its visible and Schema.org SHA-256 from the actual public JSON bytes at build time
- no real credentials, copied vendor pages, live form submissions, or network writes are part of the corpus
