### PR TITLE
docs: improve citation and discovery metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: 'If you use Authier in your work, please cite it using this metadata.'
+title: 'Authier'
+type: software
+authors:
+  - name: 'Authier contributors'
+abstract: 'Authier is an early-stage open-source password manager and TOTP vault for browsers and the web. The project has not undergone an independent security audit.'
+keywords:
+  - 'password manager'
+  - TOTP
+  - 'browser extension'
+  - autofill
+  - 'client-side encryption'
+license: AGPL-3.0-or-later
+repository-code: 'https://github.com/authier-pm/authier'
+url: 'https://www.authier.pm/'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ keep in mind that a single package can be in multiple subfolders, so if you upda
 
 ## How to run locally
 
-Refer to the subproject readmes for client-specific setup. For the new web vault, use [vault-web/README.md](/home/capaj/work-repos/authier-repos/authier2/vault-web/README.md).
+Refer to the subproject readmes for client-specific setup. For the new web vault, use [vault-web/README.md](vault-web/README.md).
 
 # Contributor financial reward scheme
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://w3id.org/codemeta/3.1",
+  "type": "SoftwareSourceCode",
+  "name": "Authier",
+  "description": "Authier is an early-stage open-source password manager and TOTP vault for browsers and the web. The project has not undergone an independent security audit.",
+  "codeRepository": "https://github.com/authier-pm/authier",
+  "issueTracker": "https://github.com/authier-pm/authier/issues",
+  "url": "https://www.authier.pm/",
+  "downloadUrl": "https://www.authier.pm/download",
+  "license": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+  "author": [
+    {
+      "type": "Organization",
+      "name": "Authier contributors",
+      "url": "https://github.com/authier-pm"
+    }
+  ],
+  "programmingLanguage": ["TypeScript", "JavaScript"],
+  "keywords": [
+    "password manager",
+    "TOTP",
+    "browser extension",
+    "autofill",
+    "client-side encryption"
+  ]
+}

--- a/landing-page/scripts/checkSeo.ts
+++ b/landing-page/scripts/checkSeo.ts
@@ -52,6 +52,38 @@ function requireMatch(
   return match
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validateDatasetMetadata(value: unknown, route: string) {
+  if (Array.isArray(value)) {
+    for (const item of value) validateDatasetMetadata(item, route)
+    return
+  }
+
+  if (!isRecord(value)) return
+
+  const schemaType = value['@type']
+  const isDataset =
+    schemaType === 'Dataset' ||
+    (Array.isArray(schemaType) && schemaType.includes('Dataset'))
+
+  if (isDataset) {
+    if (typeof value.license !== 'string' || value.license.length === 0) {
+      throw new Error(`${route}: Dataset structured data is missing a license`)
+    }
+
+    if (!isRecord(value.creator) || typeof value.creator.name !== 'string') {
+      throw new Error(`${route}: Dataset structured data is missing a creator`)
+    }
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    validateDatasetMetadata(nestedValue, route)
+  }
+}
+
 if (!existsSync(distributionDirectory)) {
   throw new Error('Build output is missing. Run the production build first.')
 }
@@ -126,7 +158,8 @@ for (const file of files) {
     /<script[^>]+type="application\/ld\+json"[^>]*>(.*?)<\/script>/gis
 
   for (const match of html.matchAll(jsonLdPattern)) {
-    JSON.parse(match[1] ?? '')
+    const structuredData: unknown = JSON.parse(match[1] ?? '')
+    validateDatasetMetadata(structuredData, route)
     structuredDataBlocks += 1
   }
 

--- a/landing-page/src/data/research.ts
+++ b/landing-page/src/data/research.ts
@@ -1,3 +1,4 @@
+import { site } from '../config'
 import type { ContentEntry } from './content'
 
 export type ResearchArtifact = ContentEntry
@@ -14,3 +15,23 @@ export const researchArtifacts = [
     category: 'Research artifact'
   }
 ] as const satisfies readonly ResearchArtifact[]
+
+const researchDatasetCreator = {
+  '@type': 'Organization',
+  name: 'Authier contributors',
+  url: site.githubUrl
+} as const
+
+const researchDatasetLicense =
+  'https://spdx.org/licenses/AGPL-3.0-or-later.html'
+
+export const createResearchDatasetSchema = (artifact: ResearchArtifact) => ({
+  '@type': 'Dataset' as const,
+  name: artifact.title,
+  description: artifact.description,
+  url: `${site.url}${artifact.href}`,
+  datePublished: artifact.publishedAt,
+  dateModified: artifact.updatedAt,
+  creator: researchDatasetCreator,
+  license: researchDatasetLicense
+})

--- a/landing-page/src/pages/blog/index.astro
+++ b/landing-page/src/pages/blog/index.astro
@@ -3,7 +3,10 @@ import Icon from '../../components/Icon.astro'
 import PageHero from '../../components/PageHero.astro'
 import { site } from '../../config'
 import { blogPosts } from '../../data/blog'
-import { researchArtifacts } from '../../data/research'
+import {
+  createResearchDatasetSchema,
+  researchArtifacts
+} from '../../data/research'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 
 const title = 'Password Manager Blog'
@@ -22,14 +25,7 @@ const schema = {
   description,
   url: `${site.url}/blog`,
   hasPart: [
-    ...researchArtifacts.map((artifact) => ({
-      '@type': 'Dataset',
-      name: artifact.title,
-      description: artifact.description,
-      url: `${site.url}${artifact.href}`,
-      datePublished: artifact.publishedAt,
-      dateModified: artifact.updatedAt
-    })),
+    ...researchArtifacts.map(createResearchDatasetSchema),
     ...blogPosts.map((post) => ({
       '@type': 'Article',
       headline: post.title,

--- a/landing-page/src/pages/research/autofill-safety-corpus.astro
+++ b/landing-page/src/pages/research/autofill-safety-corpus.astro
@@ -2,7 +2,10 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { site } from '../../config'
-import { researchArtifacts } from '../../data/research'
+import {
+  createResearchDatasetSchema,
+  researchArtifacts
+} from '../../data/research'
 import ArticleLayout from '../../layouts/ArticleLayout.astro'
 
 const [artifact] = researchArtifacts
@@ -20,19 +23,8 @@ const corpusSha256 = createHash('sha256')
 
 const datasetSchema = {
   '@context': 'https://schema.org',
-  '@type': 'Dataset',
-  name: artifact.title,
-  description: artifact.description,
-  url: `${site.url}${artifact.href}`,
+  ...createResearchDatasetSchema(artifact),
   version: '1.0.0',
-  datePublished: artifact.publishedAt,
-  dateModified: artifact.updatedAt,
-  creator: {
-    '@type': 'Organization',
-    name: 'Authier contributors',
-    url: site.githubUrl
-  },
-  license: 'https://spdx.org/licenses/AGPL-3.0-or-later.html',
   measurementTechnique: 'Synthetic jsdom classifier adapter tests',
   keywords: [
     'password manager',

--- a/landing-page/src/pages/research/autofill-safety-corpus.astro
+++ b/landing-page/src/pages/research/autofill-safety-corpus.astro
@@ -204,7 +204,12 @@ const datasetSchema = {
     evaluated generation, storage, and autofill across 13 password managers.
     The ACSAC 2024
     <a href="https://github.com/Leaky-Autofill/LeakyAutofill-Artifact" target="_blank" rel="noreferrer">Leaky Autofill artifact</a>
-    examines whether password managers fill data into concealed fields.
+    examines whether password managers fill data into concealed fields. The
+    USENIX Security 2026 paper
+    <a href="https://www.usenix.org/conference/usenixsecurity26/presentation/lamarca" target="_blank" rel="noreferrer">“AutoFail”</a>
+    studies the separate Android boundary where browsers translate web content
+    into the Autofill Framework and evaluates credential filling across browsers
+    and password managers.
   </p>
 
   <p>

--- a/landing-page/src/pages/research/index.astro
+++ b/landing-page/src/pages/research/index.astro
@@ -2,7 +2,10 @@
 import Icon from '../../components/Icon.astro'
 import PageHero from '../../components/PageHero.astro'
 import { site } from '../../config'
-import { researchArtifacts } from '../../data/research'
+import {
+  createResearchDatasetSchema,
+  researchArtifacts
+} from '../../data/research'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 
 const title = 'Password Manager Research'
@@ -15,14 +18,7 @@ const schema = {
   name: 'Authier password manager research',
   description,
   url: `${site.url}/research`,
-  hasPart: researchArtifacts.map((artifact) => ({
-    '@type': 'Dataset',
-    name: artifact.title,
-    description: artifact.description,
-    url: `${site.url}${artifact.href}`,
-    datePublished: artifact.publishedAt,
-    dateModified: artifact.updatedAt
-  }))
+  hasPart: researchArtifacts.map(createResearchDatasetSchema)
 }
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,20 @@
   "name": "authier",
   "private": true,
   "version": "1.0.0",
+  "description": "Open-source password manager and TOTP vault for browsers and the web",
+  "homepage": "https://www.authier.pm/",
   "main": "index.js",
-  "repository": "https://github.com/capaj/authier.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/authier-pm/authier.git"
+  },
+  "keywords": [
+    "password-manager",
+    "totp",
+    "browser-extension",
+    "security",
+    "typescript"
+  ],
   "authors": [
     "Petr <petrik.spac@gmail.com>",
     "Jiri Spac <capajj@gmail.com>"


### PR DESCRIPTION
## Summary

- add a schema-valid `CITATION.cff` so GitHub and research tools can expose consistent citation metadata
- replace the root package’s obsolete repository URL and add the canonical homepage and accurate discovery metadata
- repair the machine-specific web-vault README link
- add the current USENIX Security 2026 AutoFail paper to the corpus’s related-work context while keeping its Android boundary distinct

## Verification

- validated `CITATION.cff` against the official Citation File Format schema
- `pnpm --dir landing-page build`
- `pnpm --dir landing-page check:seo`
- `git diff --check`