### PR TITLE
docs(web-extension): refresh README for Vitest and current browsers

### DIFF
--- a/web-extension/README.md
+++ b/web-extension/README.md
@@ -2,9 +2,9 @@
 
 ## Running the extension build on Ubuntu
 
-To build the browser extension please follow these commands:
+To build the browser extension, follow these commands from the repository root:
 
-```
+```bash
 curl -fsSL https://get.pnpm.io/install.sh | sh -
 pnpm install
 cd web-extension
@@ -15,84 +15,107 @@ pnpm prodBuild
 ## Getting started with development
 
 Install pnpm globally: https://pnpm.io/installation
-and follow the instructions just instead `pnpm prodBuild` run `pnpm dev`
 
-**Scripts**
+From the repository root, install workspace dependencies, then work inside `web-extension`:
 
-- `pnpm dev` - run `webpack` in `watch` mode
-- `pnpm build` - builds the production-ready unpacked extension
-- `pnpm test -u` - runs Jest + updates test snapshots
-- `pnpm lint` - runs EsLint
+```bash
+pnpm install
+cd web-extension
+cp .env.example .env
+pnpm dev
+```
+
+**Scripts** (from `web-extension/package.json`)
+
+- `pnpm dev` — run webpack in watch mode (`webpack.dev.js`)
+- `pnpm devBuild` — one-shot development webpack build
+- `pnpm prodBuild` — production-ready unpacked extension into `dist/`
+- `pnpm test` — run Vitest once
+- `pnpm test:watch` — Vitest in watch mode
+- `pnpm test:ui` — Vitest UI
+- `pnpm tsc` — TypeScript check
+- `pnpm checkBuildOutput` — sanity-check webpack output parsing
+- `pnpm generateManifest` — regenerate the extension manifest
+
+From the repository root, `pnpm fmt:check web-extension/README.md` checks formatting.
 
 ## Publishing a new version to stores
 
-Chrome, Edge, and Firefox publishing is automated on CI. Run `pnpm release` to create and push a new extension tag; CI builds manifest V3 for Chrome and Edge and manifest V2 for Firefox before submitting each bundle to its store.
+Chrome, Edge, and Firefox publishing is automated on CI. Run `pnpm release` (from `web-extension`, or `pnpm release` at the repo root which delegates here) to create and push a new extension tag; CI builds Manifest V3 for Chrome and Edge and Manifest V2 for Firefox before submitting each bundle to its store.
 
-To build the Firefox manifest V2 extension locally, run `MANIFEST_VERSION=2 pnpm generateManifest && MANIFEST_VERSION=2 pnpm prodBuild`.
+To build the Firefox Manifest V2 extension locally:
+
+```bash
+MANIFEST_VERSION=2 pnpm generateManifest && MANIFEST_VERSION=2 pnpm prodBuild
+```
+
+Official install links (source of truth): [authier.pm/download](https://www.authier.pm/download) — Google Chrome, Mozilla Firefox (desktop and Firefox for Android), and Microsoft Edge. Authier ships as a browser extension only; there is no native desktop or mobile app download.
 
 <details>
-  <summary>Loading the extension in Google Chrome</summary>
+<summary>Loading the extension in Google Chrome</summary>
 
-In [Google Chrome](https://www.google.com/chrome/), open up [chrome://extensions](chrome://extensions) in a new tab. Make sure the `Developer Mode` checkbox in the upper-right corner is turned on. Click `Load unpacked` and select the `dist` directory in this repository - your extension should now be loaded.
+In [Google Chrome](https://www.google.com/chrome/), open [chrome://extensions](chrome://extensions) in a new tab. Turn on **Developer mode**, click **Load unpacked**, and select the `web-extension/dist` directory — your extension should now be loaded.
 
-![Installed Extension in Google Chrome](https://i.imgur.com/ORuHbDR.png 'Installed Extension in Google Chrome')
+![Installed Extension in Google Chrome](https://i.imgur.com/ORuHbDR.png "Installed Extension in Google Chrome")
 
 </details>
 
 <details>
-  <summary>Loading the extension in Brave</summary>
+<summary>Loading the extension in Microsoft Edge</summary>
 
-In [Brave](https://brave.com/), open up [brave://extensions](brave://extensions) in a new tab. Make sure the `Developer Mode` checkbox in the upper-right corner is turned on. Click `Load unpacked` and select the `dist` directory in this repository - your extension should now be loaded.
-
-![Installed Extension in Brave](https://i.imgur.com/z8lW02m.png 'Installed Extension in Brave')
+In [Microsoft Edge](https://www.microsoft.com/edge), open [edge://extensions](edge://extensions) in a new tab. Turn on **Developer mode**, click **Load unpacked**, and select the `web-extension/dist` directory.
 
 </details>
 
 <details>
-  <summary>Loading the extension in Mozilla Firefox</summary>
+<summary>Loading the extension in Brave</summary>
 
-In [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/), open up the [about:debugging](about:debugging) page in a new tab. Click the `Load Temporary Add-on...` button and select the `manfiest.json` from the `dist` directory in this repository - your extension should now be loaded.
+In [Brave](https://brave.com/), open [brave://extensions](brave://extensions) in a new tab. Turn on **Developer mode**, click **Load unpacked**, and select the `web-extension/dist` directory.
 
-![Installed Extension in Mozilla Firefox](https://i.imgur.com/gO2Lrb5.png 'Installed Extension in Mozilla Firefox')
+![Installed Extension in Brave](https://i.imgur.com/z8lW02m.png "Installed Extension in Brave")
+
+</details>
+
+<details>
+<summary>Loading the extension in Mozilla Firefox</summary>
+
+In [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/), open [about:debugging](about:debugging) in a new tab. Click **Load Temporary Add-on...** and select the `manifest.json` from the `web-extension/dist` directory — your extension should now be loaded.
+
+For a Firefox-oriented local build, use the Manifest V2 commands above before loading `dist`.
+
+![Installed Extension in Mozilla Firefox](https://i.imgur.com/gO2Lrb5.png "Installed Extension in Mozilla Firefox")
 
 </details>
 
 **Notes**
 
-- Includes ESLint configured to work with TypeScript and Prettier.
-
-- Includes tests with Jest - note that the `babel.config.js` and associated dependencies are only necessary for Jest to work with TypeScript.
-
-- Recommended to use `Visual Studio Code` with the `Format on Save` setting turned on.
-
+- TypeScript is checked with `pnpm tsc`. Formatting is handled at the monorepo root (`pnpm fmt` / `pnpm fmt:check`).
+- Unit tests use Vitest (`pnpm test`), not Jest.
+- Recommended: Visual Studio Code with Format on Save.
 - Example icons courtesy of [FontAwesome](https://fontawesome.com).
-
-- [Microsoft Edge](<>) is not currently supported.
-
-- Includes Storybook configured to work with React + TypeScript. Note that it maintains its own `webpack.config.js` and `tsconfig.json` files. See example story in `src/components/hello/__tests__/hello.stories.tsx`
 
 **Built with**
 
 - [React](https://reactjs.org)
 - [TypeScript](https://www.typescriptlang.org/)
-- [Jest](https://jestjs.io)
-- [Eslint](https://eslint.org/)
-- [Prettier](https://prettier.io/)
+- [Vitest](https://vitest.dev/)
 - [Webpack](https://webpack.js.org/)
-- [Babel](https://babeljs.io/)
-- [Chakra-ui](https://chakra-ui.com/)
+- [Chakra UI](https://chakra-ui.com/)
 
 **Misc. References**
 
-- [Chrome Extension Developer Guide](https://developer.chrome.com/extensions/devguide)
+- [Chrome Extension Developer Guide](https://developer.chrome.com/docs/extensions)
 - [Firefox Extension Developer Guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension)
-- [Eslint + Prettier + Typescript Guide](https://dev.to/robertcoopercode/using-eslint-and-prettier-in-a-typescript-project-53jb)
 
 ## Two modes
 
-- strict: you never have your codes on another device other than your primary phone. One code only is sent to the device from your phone after every biometric verification.
-- lax: your codes are decrypted on your devices too. You can choose a timeout to lock the vault. When unlocked, all the OTP codes are filled effortlessly without the need for your primary phone.
+- **strict:** you never have your codes on another device other than your primary phone. One code only is sent to the device from your phone after every biometric verification.
+- **lax:** your codes are decrypted on your devices too. You can choose a timeout to lock the vault. When unlocked, all the OTP codes are filled effortlessly without the need for your primary phone.
 
 ## Check output in dist
 
-since it is common to bump into a dependency which breaks webpack silently, it's best to check at least parsing on the webpack output. We can do this by `pnpm checkBuildOutput`
+Since it is common to bump into a dependency which breaks webpack silently, check parsing on the webpack output:
+
+```bash
+pnpm checkBuildOutput
+```


### PR DESCRIPTION
## Summary

Refresh web-extension README for current toolchain.

Fixes #532

## Test plan

- Cross-checked package.json scripts and authier.pm/download

Patch summary:
- Replace Jest/ESLint/Storybook/stale scripts with Vitest, TypeScript, prodBuild/devBuild/generateManifest
- Fix manfiest.json typo to manifest.json; document Manifest V2 local build
- Edge supported per download page; add Edge load-unpacked; extension-only (no native apps)
- bash fenced blocks

- Root formatting check for README pending (no local node_modules)
